### PR TITLE
Add unit test output clear during test init

### DIFF
--- a/test/unit/detail/col_layout.hpp
+++ b/test/unit/detail/col_layout.hpp
@@ -52,27 +52,29 @@ namespace rocwmma
             const int64_t sizeD = Base::mM * Base::mN;
             dataInstance->resizeStorage(probsize);
 
-            // Initialize matrix data on host
+            // Initialize data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            
+            // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD        = Base::mM * Base::mN;
-            auto          kernelResult = dataInstance->template allocHost<DataT>(sizeD);
 
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/colnt_layout.hpp
+++ b/test/unit/detail/colnt_layout.hpp
@@ -52,27 +52,29 @@ namespace rocwmma
             const int64_t sizeD = Base::mM * Base::mN;
             dataInstance->resizeStorage(probsize);
 
-            // Initialize matrix data on host
+            // Initialize data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
 
+            // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD        = Base::mM * Base::mN;
-            auto          kernelResult = dataInstance->template allocHost<DataT>(sizeD);
 
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/fill_fragment.hpp
+++ b/test/unit/detail/fill_fragment.hpp
@@ -60,24 +60,23 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(
                 dataInstance->hostIn().get(), Base::mM, Base::mN, Base::mParam1);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD = Base::mM * Base::mN;
 
-            auto kernelResult = dataInstance->template allocHost<DataT>(sizeD);
-
-            // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+                       // Cache current kernel result from device
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/load_contamination.hpp
+++ b/test/unit/detail/load_contamination.hpp
@@ -75,16 +75,21 @@ namespace rocwmma
             dataInstance->copyData(dataInstance->deviceIn(),
                                    dataInstance->hostIn(),
                                    std::get<0>(paddedProbSize) * std::get<1>(paddedProbSize));
+
+            // Initialize device output data with NaN
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), Base::mM * Base::mN);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Re-use host in memory for result
             // Use M x N as output is not padded
             const int64_t sizeD        = Base::mM * Base::mN;
-            auto&         kernelResult = dataInstance->hostIn();
+            auto&         kernelResult = dataInstance->hostOut();
 
             // Cache current kernel result from device
             dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);

--- a/test/unit/detail/map_block_to_matrix.hpp
+++ b/test/unit/detail/map_block_to_matrix.hpp
@@ -54,26 +54,27 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
-            const int64_t sizeD = Base::mM * Base::mN;
-
-            auto kernelResult = dataInstance->template allocHost<DataT>(sizeD);
+            const int64_t sizeD        = Base::mM * Base::mN;
 
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/map_block_to_matrix_override.hpp
+++ b/test/unit/detail/map_block_to_matrix_override.hpp
@@ -81,12 +81,12 @@ namespace rocwmma
             dataInstance->resizeStorage(probsize);
 
             // Initialize matrix data on host
-            MatrixUtil<Layout>::template fill<DataT>(
-                dataInstance->hostIn().get(), Base::mM, Base::mN, (DataT)0);
-            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostIn(), sizeD);
-
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
@@ -94,10 +94,7 @@ namespace rocwmma
             auto& dataInstance = Base::DataStorage::instance();
 
             const int64_t sizeD = Base::mM * Base::mN;
-
-            // Allocate and cache host memory for device result
-            auto kernelResult = dataInstance->template allocHost<DataT>(sizeD);
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             // Allocate host memory for reference calcs
             auto& hostInput   = dataInstance->hostIn();
@@ -154,7 +151,7 @@ namespace rocwmma
             
             double errorTolerance = 1.0;
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              hostResult.get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/map_matrix_to_data.hpp
+++ b/test/unit/detail/map_matrix_to_data.hpp
@@ -54,26 +54,27 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            
+            // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD = Base::mM * Base::mN;
 
-            auto kernelResult = dataInstance->template allocHost<DataT>(sizeD);
-
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/map_thread_to_matrix.hpp
+++ b/test/unit/detail/map_thread_to_matrix.hpp
@@ -54,26 +54,26 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD = Base::mM * Base::mN;
 
-            auto kernelResult = dataInstance->template allocHost<DataT>(sizeD);
-
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/map_wave_to_matrix.hpp
+++ b/test/unit/detail/map_wave_to_matrix.hpp
@@ -54,26 +54,26 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD = Base::mM * Base::mN;
 
-            auto kernelResult = dataInstance->template allocHost<DataT>(sizeD);
-
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/row_layout.hpp
+++ b/test/unit/detail/row_layout.hpp
@@ -54,25 +54,26 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl()
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD        = Base::mM * Base::mN;
-            auto          kernelResult = dataInstance->template allocHost<DataT>(sizeD);
 
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/rownt_layout.hpp
+++ b/test/unit/detail/rownt_layout.hpp
@@ -52,27 +52,29 @@ namespace rocwmma
             const int64_t sizeD = Base::mM * Base::mN;
             dataInstance->resizeStorage(probsize);
 
-            // Initialize matrix data on host
+            // Initialize data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
+            MatrixUtil<Layout>::fill(
+                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
 
+            // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
         }
 
         void validateResultsImpl()
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
             const int64_t sizeD        = Base::mM * Base::mN;
-            auto          kernelResult = dataInstance->template allocHost<DataT>(sizeD);
 
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
 
             double errorTolerance = 10.0;
 
             std::tie(Base::mValidationResult, Base::mMaxRelativeError)
-                = compareEqual<DataT, DataT, Layout, Layout>(kernelResult.get(),
+                = compareEqual<DataT, DataT, Layout, Layout>(dataInstance->hostOut().get(),
                                                              dataInstance->hostIn().get(),
                                                              Base::mM,
                                                              Base::mN,

--- a/test/unit/detail/store_contamination.hpp
+++ b/test/unit/detail/store_contamination.hpp
@@ -69,20 +69,18 @@ namespace rocwmma
                 dataInstance->deviceIn(), dataInstance->hostIn(), paddedElements);
 
             // Initialize output data on host (padded size, all with marker elements)
-            auto outputInit = dataInstance->template allocHost<DataT>(paddedElements);
-            MatrixUtil<Layout>::fill(outputInit.get(),
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
                                      std::get<0>(paddedProbSize),
                                      std::get<1>(paddedProbSize),
                                      std::numeric_limits<DataT>::max());
-            dataInstance->copyData(dataInstance->deviceOut(), outputInit, paddedElements);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), paddedElements);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
-            auto& kernelResult = dataInstance->hostIn();
+            auto& kernelResult = dataInstance->hostOut();
 
-            // Re-use host in memory for result
             // Use padded MxN as output is padded
             auto          paddedSize     = dataInstance->problemSize();
             const int64_t paddedElements = std::get<0>(paddedSize) * std::get<1>(paddedSize);

--- a/test/unit/detail/vector_iterator.hpp
+++ b/test/unit/detail/vector_iterator.hpp
@@ -53,21 +53,20 @@ namespace rocwmma
             // Need at least 1 element for the result
             auto& dataInstance = Base::DataStorage::instance();
             dataInstance->resizeStorage(probsize);
+
+            dataInstance->hostOut().get()[0] = static_cast<DataT>(ERROR_VALUE);
+            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), 1);
         }
 
         void validateResultsImpl() final
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            // Allocated managed memory for results on host
-            const int64_t sizeD        = Base::mM * Base::mN;
-            auto          kernelResult = dataInstance->template allocHost<DataT>(sizeD);
-
             // Cache current kernel result from device
-            dataInstance->copyData(kernelResult, dataInstance->deviceOut(), sizeD);
+            dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), 1);
 
             // Check the single output result
-            Base::mValidationResult = (kernelResult[0] == DataT(SUCCESS));
+            Base::mValidationResult = (dataInstance->hostOut().get()[0] == DataT(SUCCESS));
         }
 
         typename Base::KernelFunc kernelImpl() const final

--- a/test/unit/device/vector_iterator.hpp
+++ b/test/unit/device/vector_iterator.hpp
@@ -341,8 +341,9 @@ namespace rocwmma
                                    DataT        param1,
                                    DataT        param2)
     {
-        // Test is for any thread
-        if(threadIdx.x == 0 && threadIdx.y == 0)
+        // Just need one thread
+        if(threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0 &&
+           blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0)
         {
             out[0] = static_cast<DataT>(SUCCESS);
 

--- a/test/unit/unit_resource.hpp
+++ b/test/unit/unit_resource.hpp
@@ -83,6 +83,7 @@ namespace rocwmma
         void resizeStorage(ProblemSize const& size);
 
         HostPtrT&   hostIn();
+        HostPtrT&   hostOut();
         DevicePtrT& deviceIn();
         DevicePtrT& deviceOut();
 
@@ -91,7 +92,7 @@ namespace rocwmma
 
     protected:
         DevicePtrT  mDeviceIn, mDeviceOut;
-        HostPtrT    mHostIn;
+        HostPtrT    mHostIn, mHostOut;
         ProblemSize mCurrentProblemSize;
         int64_t     mMaxCapacity;
     };

--- a/test/unit/unit_resource_impl.hpp
+++ b/test/unit/unit_resource_impl.hpp
@@ -40,6 +40,7 @@ namespace rocwmma
         : mDeviceIn(nullptr, [](DataT*) {})
         , mDeviceOut(nullptr, [](DataT*) {})
         , mHostIn(nullptr)
+        , mHostOut(nullptr)
         , mCurrentProblemSize({0, 0})
         , mMaxCapacity(0)
     {
@@ -54,6 +55,7 @@ namespace rocwmma
         {
             mMaxCapacity = newSize;
             mHostIn      = std::move(Base::template allocHost<DataT>(mMaxCapacity));
+            mHostOut      = std::move(Base::template allocHost<DataT>(mMaxCapacity));
             mDeviceIn    = std::move(Base::template allocDevice<DataT>(mMaxCapacity));
             mDeviceOut   = std::move(Base::template allocDevice<DataT>(mMaxCapacity));
         }
@@ -64,6 +66,12 @@ namespace rocwmma
     auto UnitResource<DataT>::hostIn() -> HostPtrT&
     {
         return mHostIn;
+    }
+
+    template <typename DataT>
+    auto UnitResource<DataT>::hostOut() -> HostPtrT&
+    {
+        return mHostOut;
     }
 
     template <typename DataT>


### PR DESCRIPTION
- Shared data arrays should be cleared between runs