### PR TITLE
Default to Row4T for accumulator

### DIFF
--- a/test/unit/device/rownt_layout.hpp
+++ b/test/unit/device/rownt_layout.hpp
@@ -51,8 +51,10 @@ namespace rocwmma
             BlockDim = BlockN,
             KDim     = BlockM,
 
-            MaxVectorWidth = detail::VecWidthTraits<BlockDim, KDim, DataT>::MaxVectorWidth,
-            VectorWidth    = std::is_same<LayoutP, row_major>::value ? MaxVectorWidth : 1
+            MaxVectorWidth = std::is_same<DataT, float64_t>::value
+                                    ? 1
+                                    : 4, // Actual output of the mfma hardware
+            VectorWidth    = std::is_same<DataLayout, col_major>::value ? MaxVectorWidth : 1,
         };
 
         using IOTraits = IOTraits<BlockDim, KDim, DataT, VectorWidth>;

--- a/test/unit/device/rownt_layout.hpp
+++ b/test/unit/device/rownt_layout.hpp
@@ -77,9 +77,8 @@ namespace rocwmma
             for(uint32_t j = 0; j < VectorWidth; j++)
             {
                 auto index
-                    = (std::get<MajorIndex>(matrixCoord) + std::get<MajorIndex>(baseOffset) + j)
-                          * ld
-                      + (std::get<MinorIndex>(matrixCoord) + std::get<MinorIndex>(baseOffset));
+                    = (std::get<MajorIndex>(matrixCoord) * ld + std::get<MinorIndex>(matrixCoord))
+                      + Mapping::dataOffset(baseOffset, ld) + j;
                 out[index] = in[index];
             }
             baseOffset += LayoutT::incrementalOffset(i);

--- a/test/unit/device/rownt_layout.hpp
+++ b/test/unit/device/rownt_layout.hpp
@@ -53,8 +53,8 @@ namespace rocwmma
 
             MaxVectorWidth = std::is_same<DataT, float64_t>::value
                                     ? 1
-                                    : 4, // Actual output of the mfma hardware
-            VectorWidth    = std::is_same<DataLayout, col_major>::value ? MaxVectorWidth : 1,
+                                    : detail::VecWidthTraits<BlockDim, KDim, DataT>::MaxVectorWidth,
+            VectorWidth    = std::is_same<LayoutP, col_major>::value ? MaxVectorWidth : 1,
         };
 
         using IOTraits = IOTraits<BlockDim, KDim, DataT, VectorWidth>;


### PR DESCRIPTION
Modify the RowNT device function to use default IO shape of the accumulator