### PR TITLE
Fix resource alloc tracking

### DIFF
--- a/test/gemm/gemm_kernel_base.hpp
+++ b/test/gemm/gemm_kernel_base.hpp
@@ -58,7 +58,7 @@ namespace rocwmma
         virtual void          validateResults()                                   = 0;
         virtual void          reportResults()                                     = 0;
         virtual void          tearDown()                                          = 0;
-        virtual HipResource*  getResource()                                       = 0;
+        virtual HipResource*  getResource() const                                 = 0;
         virtual std::ostream& printHeader(std::ostream& stream = std::cout) const = 0;
         virtual std::ostream& printKernel(std::ostream& stream = std::cout) const = 0;
 
@@ -140,7 +140,7 @@ namespace rocwmma
         virtual void          validateResults() override;
         virtual void          reportResults() override;
         virtual void          tearDown() override;
-        virtual HipResource*  getResource() override;
+        virtual HipResource*  getResource() const override;
         virtual std::ostream& printHeader(std::ostream& stream = std::cout) const override;
         virtual std::ostream& printKernel(std::ostream& stream = std::cout) const override;
 

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -338,7 +338,7 @@ namespace rocwmma
                                 LayoutA,
                                 LayoutB,
                                 LayoutC,
-                                LayoutD>::getResource()
+                                LayoutD>::getResource() const
     {
         return DataStorage::instance().get();
     }
@@ -504,8 +504,10 @@ namespace rocwmma
             MatrixUtil<LayoutA>::fillLaunchKernel(dataInstance->deviceA().get(), mM, mK);
             MatrixUtil<LayoutB>::fillLaunchKernel(dataInstance->deviceB().get(), mK, mN);
             MatrixUtil<LayoutC>::fillLaunchKernel(dataInstance->deviceC().get(), mM, mN);
-            MatrixUtil<LayoutD>::fillLaunchKernel(
-                dataInstance->deviceD().get(), mM, mN, std::numeric_limits<OutputT>::signaling_NaN());
+            MatrixUtil<LayoutD>::fillLaunchKernel(dataInstance->deviceD().get(),
+                                                  mM,
+                                                  mN,
+                                                  std::numeric_limits<OutputT>::signaling_NaN());
 
             // Copy to host if performing cpu validation
 #if !defined(ROCWMMA_VALIDATE_WITH_ROCBLAS) && defined(ROCWMMA_VALIDATION_TESTS)
@@ -671,7 +673,10 @@ namespace rocwmma
 
                 // Reset device D with NaN
                 MatrixUtil<LayoutD>::fillLaunchKernel(
-                    dataInstance->deviceD().get(), mM, mN, std::numeric_limits<OutputT>::signaling_NaN());
+                    dataInstance->deviceD().get(),
+                    mM,
+                    mN,
+                    std::numeric_limits<OutputT>::signaling_NaN());
 
                 // Move the ROCWMMA result to host for analysis
                 dataInstance->copyData(dataInstance->hostD(), rocwmmaResult, mM * mN);

--- a/test/gemm/gemm_resource.hpp
+++ b/test/gemm/gemm_resource.hpp
@@ -67,7 +67,7 @@ namespace rocwmma
         using ProblemSize = std::tuple<int64_t, int64_t, int64_t>;
 
         // MatrixA, MatrixB, MatrixCD (# of elements)
-        using MatrixSize = std::tuple<int64_t, int64_t, int64_t>;
+        using MatrixSize = std::tuple<int64_t, int64_t, int64_t, int64_t>;
 
         enum : uint32_t
         {
@@ -75,7 +75,7 @@ namespace rocwmma
             MatrixA = 0,
             MatrixB = 1,
             MatrixC = 2,
-            MatrixD = 2,
+            MatrixD = 3,
 
             // Problem size indices
             M = 0,
@@ -114,6 +114,7 @@ namespace rocwmma
         HostPtrT<OutputT>   mHostC, mHostD;
         ProblemSize         mCurrentProblemSize;
         MatrixSize          mCurrentMatrixSize;
+        MatrixSize          mCurrentAllocSize;
     };
 
 } // namespace rocwmma

--- a/test/gemm/gemm_resource.hpp
+++ b/test/gemm/gemm_resource.hpp
@@ -94,11 +94,6 @@ namespace rocwmma
         GemmResource(GemmResource&&);
         ~GemmResource() = default;
 
-        template <typename DataT>
-        static inline void reallocDeviceHostPair(DevicePtrT<DataT>& devicePtr,
-                                                 HostPtrT<DataT>&   hostPtr,
-                                                 int64_t            numElements);
-
         void copyHostToDeviceAll();
         void copyDeviceToHostAll();
         void resizeStorage(ProblemDims const& size);

--- a/test/gemm/gemm_resource_impl.hpp
+++ b/test/gemm/gemm_resource_impl.hpp
@@ -49,7 +49,7 @@ namespace rocwmma
     }
 
     template <typename InputT, typename OutputT>
-    GemmResource<InputT, OutputT>::GemmResource(GemmResource&& rhs)
+    GemmResource<InputT, OutputT>::GemmResource(GemmResource<InputT, OutputT>&& rhs)
         : HipResource()
         , mDeviceA(std::move(rhs.mDeviceA))
         , mDeviceB(std::move(rhs.mDeviceB))
@@ -62,16 +62,6 @@ namespace rocwmma
         , mCurrentMatrixElements(rhs.mCurrentMatrixElements)
         , mCurrentAllocElements(rhs.mCurrentAllocElements)
     {
-    }
-
-    template <typename InputT, typename OutputT>
-    template <typename DataT>
-    inline void GemmResource<InputT, OutputT>::reallocDeviceHostPair(DevicePtrT<DataT>& devicePtr,
-                                                                     HostPtrT<DataT>&   hostPtr,
-                                                                     int64_t            numElements)
-    {
-        Base::reallocDevice(devicePtr, numElements);
-        Base::reallocHost(hostPtr, numElements);
     }
 
     template <typename InputT, typename OutputT>
@@ -112,7 +102,7 @@ namespace rocwmma
             // Only realloc if required (e.g. current allocation won't fit new sizes)
             if(currentAllocElements < newAllocElements)
             {
-                reallocDeviceHostPair(devicePtr, hostPtr, newAllocElements);
+                Base::reallocDeviceHostPair(devicePtr, hostPtr, newAllocElements);
                 currentAllocElements = newAllocElements;
             }
         };
@@ -141,10 +131,10 @@ namespace rocwmma
     template <typename InputT, typename OutputT>
     void GemmResource<InputT, OutputT>::reset()
     {
-        reallocDeviceHostPair(mDeviceA, mHostA, 0);
-        reallocDeviceHostPair(mDeviceB, mHostB, 0);
-        reallocDeviceHostPair(mDeviceC, mHostC, 0);
-        reallocDeviceHostPair(mDeviceD, mHostD, 0);
+        Base::reallocDeviceHostPair(mDeviceA, mHostA, 0);
+        Base::reallocDeviceHostPair(mDeviceB, mHostB, 0);
+        Base::reallocDeviceHostPair(mDeviceC, mHostC, 0);
+        Base::reallocDeviceHostPair(mDeviceD, mHostD, 0);
         mCurrentAllocElements  = {0, 0, 0, 0};
         mCurrentMatrixElements = {0, 0, 0, 0};
     }

--- a/test/gemm/test/gemm_test.hpp
+++ b/test/gemm/test/gemm_test.hpp
@@ -58,13 +58,15 @@ namespace rocwmma
             auto alpha       = std::get<3>(param);
             auto beta        = std::get<4>(param);
 
-            // Cleanup previously used resources if data types change
-            static KernelI* sLastKernelRun = nullptr;
-            if (sLastKernelRun && sLastKernelRun->getResource() != kernel->getResource())
+            // Cleanup previously used resources if the resource context changes.
+            // This happens in GEMM when the Input/Output types change for test batches.
+            // Eg. tests change from f16 to f32
+            static HipResource* sLastResourceRun = nullptr;
+            if(sLastResourceRun && sLastResourceRun != kernel->getResource())
             {
-                sLastKernelRun->getResource()->reset();
+                sLastResourceRun->reset();
             }
-            sLastKernelRun = kernel.get();
+            sLastResourceRun = kernel->getResource();
 
             ProblemParams params = {threadBlock, problemSize, alpha, beta};
 

--- a/test/hip_resource.hpp
+++ b/test/hip_resource.hpp
@@ -69,6 +69,11 @@ namespace rocwmma
         template <typename DataT>
         static inline void reallocHost(HostPtrT<DataT>& hostPtr, int64_t numElements);
 
+        template <typename DataT>
+        static inline void reallocDeviceHostPair(DevicePtrT<DataT>& devicePtr,
+                                                 HostPtrT<DataT>&   hostPtr,
+                                                 int64_t            numElements);
+
         // Transfer wrappers
         template <typename DataT>
         static void

--- a/test/hip_resource.hpp
+++ b/test/hip_resource.hpp
@@ -38,10 +38,16 @@ namespace rocwmma
 
     struct HipResource
     {
-        HipResource()                   = default;
-        ~HipResource()                  = default;
+    protected:
+        HipResource() = default;
+
+    private: // No Copy
+        HipResource(HipResource&&)      = delete;
         HipResource(const HipResource&) = delete;
         HipResource& operator=(const HipResource&) = delete;
+
+    public:
+        virtual ~HipResource() = default;
 
         // Types
         template <typename DataT>
@@ -52,10 +58,16 @@ namespace rocwmma
 
         // Alloc
         template <typename DataT>
-        static DevicePtrT<DataT> allocDevice(int64_t numElements);
+        static inline DevicePtrT<DataT> allocDevice(int64_t numElements);
 
         template <typename DataT>
-        static HostPtrT<DataT> allocHost(int64_t numElements);
+        static inline void reallocDevice(DevicePtrT<DataT>& devicePtr, int64_t numElements);
+
+        template <typename DataT>
+        static inline HostPtrT<DataT> allocHost(int64_t numElements);
+
+        template <typename DataT>
+        static inline void reallocHost(HostPtrT<DataT>& hostPtr, int64_t numElements);
 
         // Transfer wrappers
         template <typename DataT>

--- a/test/hip_resource_impl.hpp
+++ b/test/hip_resource_impl.hpp
@@ -66,6 +66,15 @@ namespace rocwmma
     }
 
     template <typename DataT>
+    inline void HipResource::reallocDeviceHostPair(DevicePtrT<DataT>& devicePtr,
+                                                   HostPtrT<DataT>&   hostPtr,
+                                                   int64_t            numElements)
+    {
+        reallocDevice(devicePtr, numElements);
+        reallocHost(hostPtr, numElements);
+    }
+
+    template <typename DataT>
     void HipResource::copyData(HostPtrT<DataT>&         dst,
                                DevicePtrT<DataT> const& src,
                                int64_t                  numElements)

--- a/test/hip_resource_impl.hpp
+++ b/test/hip_resource_impl.hpp
@@ -36,31 +36,33 @@ namespace rocwmma
 {
 
     template <typename DataT>
-    auto HipResource::allocDevice(int64_t numElements) -> DevicePtrT<DataT>
+    auto inline HipResource::allocDevice(int64_t numElements) -> DevicePtrT<DataT>
     {
-        if(numElements <= 0)
-        {
-            return {nullptr, [](DataT*) {}};
-        }
-        else
-        {
-            DataT* data;
-            CHECK_HIP_ERROR(hipMalloc(&data, numElements * sizeof(DataT)));
-            return DevicePtrT<DataT>(data, [](DataT* d) { CHECK_HIP_ERROR(hipFree(d)); });
-        }
+        DataT* data;
+        CHECK_HIP_ERROR(hipMalloc(&data, numElements * sizeof(DataT)));
+        return DevicePtrT<DataT>(data, [](DataT* d) { CHECK_HIP_ERROR(hipFree(d)); });
+    }
+
+    template <typename DataT>
+    inline void HipResource::reallocDevice(DevicePtrT<DataT>& devicePtr, int64_t numElements)
+    {
+        // Free existing ptr first before alloc in case of big sizes.
+        devicePtr.reset(nullptr);
+        devicePtr = std::move(allocDevice<DataT>(numElements));
     }
 
     template <typename DataT>
     auto HipResource::allocHost(int64_t numElements) -> HostPtrT<DataT>
     {
-        if(numElements <= 0)
-        {
-            return {nullptr};
-        }
-        else
-        {
-            return HostPtrT<DataT>(new DataT[numElements]);
-        }
+        return HostPtrT<DataT>(new DataT[numElements]);
+    }
+
+    template <typename DataT>
+    inline void HipResource::reallocHost(HostPtrT<DataT>& hostPtr, int64_t numElements)
+    {
+        // Free existing ptr first before alloc in case of big sizes.
+        hostPtr.reset(nullptr);
+        hostPtr = std::move(allocHost<DataT>(numElements));
     }
 
     template <typename DataT>

--- a/test/singleton.hpp
+++ b/test/singleton.hpp
@@ -36,7 +36,7 @@ namespace rocwmma
     class LazySingleton
     {
     public:
-        static std::unique_ptr<T> const& instance()
+        static inline std::unique_ptr<T> const& instance()
         {
             static auto sInstance = std::make_unique<T>();
             return sInstance;


### PR DESCRIPTION
PR hotfix for GemmResource allocation tracking:

Two issues:
1. Allocation size is overwritten by matrix size every time there is a resize.
   - Every time newSize increases, reallocation is done, which is partially correct.
   - If newSize decreases, the allocation count incorrectly decreased which would trigger re-alloc on next increase.

2. Copy to and from host needs to track the matrix size, not the allocation size.

- Fixes hip allocation error on repeated test runs.

- Improves readability of GemmResource class.

- Reduces risk of referencing dead pointer on resource reset. Now points to static resource class which is guaranteed alive during testing lifetime, instead of kernel class with unknown lifetime.

- Includes various fixes for code quality.