### PR TITLE
Data handling improvements.

### DIFF
--- a/library/include/rocwmma/internal/broadcast.hpp
+++ b/library/include/rocwmma/internal/broadcast.hpp
@@ -37,22 +37,16 @@ namespace rocwmma
     {
         struct Traits
         {
-            using OutputT = VecT<DataT, VectorSize>;
+            using BroadcastT = VecT<DataT, VectorSize>;
         };
 
-        __device__ static inline auto exec(DataT val) -> typename Traits::OutputT
+        __device__ static inline void exec(typename Traits::BroadcastT& data, DataT val)
         {
-            using OutputT = typename Traits::OutputT;
-
-            OutputT output;
-
 #pragma unroll
-            for(unsigned int i = 0; i < OutputT::size(); i++)
+            for(unsigned int i = 0; i < Traits::BroadcastT::size(); i++)
             {
-                output[i] = val;
+                data[i] = val;
             }
-
-            return output;
         }
     };
 

--- a/library/include/rocwmma/internal/constants.hpp
+++ b/library/include/rocwmma/internal/constants.hpp
@@ -36,6 +36,7 @@ namespace rocwmma
 
     static constexpr uint32_t AMDGCN_LDS_MAX_SIZE_BYTES    = 65536;
     static constexpr uint32_t AMDGCN_CACHE_LINE_SIZE_BYTES = 64;
+    static constexpr uint32_t AMDGCN_DWORD_SIZE_BYTES = 4;
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/coop_load.hpp
+++ b/library/include/rocwmma/internal/coop_load.hpp
@@ -70,8 +70,8 @@ namespace rocwmma
             static_assert(OutputT::size() / SplitCount >= 1, "Partial registers not supported");
         };
 
-        __device__ static inline void exec(typename Traits::OutputT& output,
-                                           DataT const*              loadPtr,
+        __device__ static inline void exec(typename Traits::OutputT& data,
+                                           DataT const*              dataPtr,
                                            uint32_t                  ldm,
                                            uint32_t                  waveIndex,
                                            uint32_t                  waveCount)
@@ -86,7 +86,7 @@ namespace rocwmma
             auto baseOffset = MatrixMapper::baseOffset();
 
             // Break down block into iterable loads
-            auto splitIter = output.template begin<Traits::LoadT::size()>();
+            auto splitIter = data.template begin<Traits::LoadT::size()>();
 
 #pragma unroll
             for(uint32_t i = 0; i < Traits::SplitCount; ++i)
@@ -97,8 +97,9 @@ namespace rocwmma
 #pragma unroll
                     for(uint32_t j = 0; j < Traits::SplitIOCount; ++j)
                     {
-                        *ioIter = *Loader::exec(
-                            loadPtr,
+                        Loader::exec(
+                            *ioIter,
+                            dataPtr,
                             DataMapper::fromMatrixCoord(
                                 baseOffset + MatrixMapper::cumulativeOffset(ioIter.index()), ldm));
                         ioIter++;

--- a/library/include/rocwmma/internal/coop_store.hpp
+++ b/library/include/rocwmma/internal/coop_store.hpp
@@ -70,8 +70,8 @@ namespace rocwmma
             static_assert(InputT::size() / SplitCount >= 1, "Partial registers not supported");
         };
 
-        __device__ static inline void exec(DataT*                         storePtr,
-                                           typename Traits::InputT const& input,
+        __device__ static inline void exec(DataT*                         dataPtr,
+                                           typename Traits::InputT const& data,
                                            uint32_t                       ldm,
                                            uint32_t                       waveIndex,
                                            uint32_t                       waveCount)
@@ -86,7 +86,7 @@ namespace rocwmma
             auto baseOffset = MatrixMapper::baseOffset();
 
             // Break down block into iterable stores
-            auto splitIter = input.template begin<Traits::StoreT::size()>();
+            auto splitIter = data.template begin<Traits::StoreT::size()>();
 
 #pragma unroll
             for(uint32_t i = 0; i < Traits::SplitCount; ++i)
@@ -98,7 +98,7 @@ namespace rocwmma
                     for(uint32_t j = 0; j < Traits::SplitIOCount; ++j)
                     {
                         Storer::exec(
-                            storePtr,
+                            dataPtr,
                             *ioIter,
                             DataMapper::fromMatrixCoord(
                                 baseOffset + MatrixMapper::cumulativeOffset(ioIter.index()), ldm));

--- a/library/include/rocwmma/internal/io_traits.hpp
+++ b/library/include/rocwmma/internal/io_traits.hpp
@@ -154,18 +154,19 @@ namespace rocwmma
         };
 
         /*
-* The following class is intended to provide optimistic suggestions for
-* IO vector widths. Given a certain block size, search for largest
-* vector width that could potentially be used during IO.
-*
-* Start testing at a default width of BlockK. Keep halving the vector width
-* until it can fit the entire block, or split evenly amongst IO iterations.
-*/
+        * The following class is intended to provide optimistic suggestions for
+        * IO vector widths. Given a certain block size, search for largest
+        * vector width that could potentially be used during IO, up to a maximum of
+        * dwordx4.
+        *
+        * Start testing at a default width of BlockK. Keep halving the vector width
+        * until it can fit the entire block, or split evenly amongst IO iterations.
+        */
 
         template <uint32_t BlockDim,
                   uint32_t BlockK,
                   typename DataT,
-                  uint32_t TestWidth = AMDGCN_CACHE_LINE_SIZE_BYTES / sizeof(DataT)>
+                  uint32_t TestWidth = AMDGCN_DWORD_SIZE_BYTES * 4 / sizeof(DataT)>
         struct VecWidthTraits
         {
             enum : uint32_t

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -105,7 +105,7 @@ namespace rocwmma
     /*! \struct layout_t
  *  \brief Definition of Runtime data layout flags
  *  @var mem_row_major
- *  @var mem_col_major 
+ *  @var mem_col_major
  */
     enum layout_t : uint32_t
     {
@@ -117,7 +117,7 @@ namespace rocwmma
     {
         /*! \struct VectorStorage
         *  \brief Vectorized internal storage
-        *  @tparam T Storage type 
+        *  @tparam T Storage type
         *  @tparam Elements No of Elements in the vector
         *  @tparam IsNativType Native or rocWMMA defined
         */
@@ -153,7 +153,7 @@ namespace rocwmma
 
     /*! \class VecT
     *  \brief  Functional vector class
-    *  @tparam T Vector data type 
+    *  @tparam T Vector data type
     *  @tparam VecSize Vector storage size
     */
     template <typename T, uint32_t VecSize>
@@ -190,10 +190,8 @@ namespace rocwmma
             struct Traits
             {
                 // Iterates over sub-vector type (may be > 1)
-                using ItVecT = typename std::conditional_t<
-                    IsConst,
-                    detail::VectorStorage_internal<DataT, SubVecSize> const,
-                    detail::VectorStorage_internal<DataT, SubVecSize>>;
+                using ItVecT = typename std::
+                    conditional_t<IsConst, VecT<DataT, SubVecSize> const, VecT<DataT, SubVecSize>>;
 
                 enum : int32_t
                 {

--- a/library/include/rocwmma/rocwmma_coop_impl.hpp
+++ b/library/include/rocwmma/rocwmma_coop_impl.hpp
@@ -49,25 +49,21 @@ namespace rocwmma
                               uint32_t splitCount)
     {
         using FragT      = typename std::decay<decltype(frag)>::type;
-        using Config     = typename FragT::IOConfig;
-        using Packer     = typename Config::Packer;
-        using CoopLoader = typename Config::CoopLoader;
+        using CoopLoader = typename FragT::IOConfig::CoopLoader;
 
         // Sanity checks
         static_assert(!std::is_same<DataLayout, void>::value,
                       "Must provide layout information. Either statically assign data layout in "
                       "fragment declaration or use the run-time function overload.");
 
-        static_assert(
-            std::is_same<typename FragT::Traits::StorageT, typename Packer::Traits::OutputT>::value,
-            "Fragment storage type and packed types do not match");
+        static_assert(std::is_same<typename FragT::Traits::AccessT,
+                                   typename CoopLoader::Traits::OutputT>::value,
+                      "Fragment access and coop load output types do not match");
 
-        typename CoopLoader::Traits::OutputT unpacked;
-
-        // Each cooperative wave only loads the portion they are responsible for
-        // Note: the read frag will only be partially filled with useful data
-        CoopLoader::exec(unpacked, data, ldm, waveIndex, waveCount, splitCount);
-        (*frag) = Packer::exec(unpacked);
+        // Load and implicit pack
+        // Note: the frag will only be partially filled with useful data.
+        // Layout and thread locality is not guaranteed.
+        CoopLoader::exec(frag.mAccess, data, ldm, waveIndex, waveCount, splitCount);
     }
 
     template <typename MatrixT,
@@ -129,22 +125,21 @@ namespace rocwmma
     {
 
         using FragT      = typename std::decay<decltype(frag)>::type;
-        using Config     = typename FragT::IOConfig;
-        using CoopStorer = typename Config::CoopStorer;
-        using Unpacker   = typename Config::Unpacker;
+        using CoopStorer = typename FragT::IOConfig::CoopStorer;
 
         // Sanity checks
         static_assert(!std::is_same<DataLayout, void>::value,
                       "Must provide data layout. Either statically assign data layout in "
                       "fragment declaration or use the run-time function overload.");
 
-        static_assert(std::is_same<typename FragT::Traits::StorageT,
-                                   typename Unpacker::Traits::InputT>::value,
-                      "Fragment storage type and packed types do not match");
+        static_assert(std::is_same<typename FragT::Traits::AccessT,
+                                   typename CoopStorer::Traits::InputT>::value,
+                      "Fragment access and coop stor input types do not match");
 
-        // Each cooperative wave only stores the portion they are responsible for
-        // Note: the write frag is only partially filled with useful data
-        CoopStorer::exec(data, Unpacker::exec(*frag), ldm, waveIndex, waveCount, splitCount);
+        // Implicit unpack and store
+        // Note: the frag is only be partially filled with useful data.
+        // Layout and thread locality is not guaranteed.
+        CoopStorer::exec(data, frag.mAccess, ldm, waveIndex, waveCount, splitCount);
     }
 
     template <typename MatrixT,


### PR DESCRIPTION
1. The current low level loading pattern returns a load result, which can result in an unwanted copy between vector registers.

The rocWMMA API employs the 'visit' pattern to use pre-allocated resources by reference, which we should reflect in the lower levels as well.

Performance changes (between runs of mma_sync_multi_lds_test-validate):

* 29% of kernels experience significant relative performance gains ( > 5% )

* 69% of kernels experience little or insignificant relative performance gains or losses ( <= %5 )

* 2% of kernels experience significant relative performance drops ( > 5% ) (*mostly with smaller sizes that are more variable in timings)

2. Use implicit packing by accessing the proper fragment data union member. Instead of forcing through external static function, the compiler should be able to determine packing from using either StorageT or AccessT types for better optimization opportunities.

3. Adjust the MaxVectorWidth property calculation to a maximum size of dwordx4. 
* This is the widest available global load assembly instruction anyway
* Improves the chances for cooperative load / store splitting amongst several waves. Otherwise if MaxVectorWidth is too large, one wave will do all the work which is inefficient