### PR TITLE
Add a compile time flag to check for available GPUS

### DIFF
--- a/test/dlrm/dlrm_kernel_base_impl.hpp
+++ b/test/dlrm/dlrm_kernel_base_impl.hpp
@@ -100,7 +100,7 @@ namespace rocwmma
     bool DlrmKernelBase<TileSize, DataT>::checkDevice() const
     {
         auto deviceArch = DeviceInfo::instance()->getGcnArch();
-        return (deviceArch != DeviceInfo::UNKNOWN
+        return (deviceArch != DeviceInfo::UNSUPPORTED
                 && !(deviceArch == DeviceInfo::GFX908 && std::is_same<DataT, float64_t>::value));
     }
 

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -198,7 +198,7 @@ namespace rocwmma
                         LayoutD>::checkDevice() const
     {
         auto deviceArch = DeviceInfo::instance()->getGcnArch();
-        return (deviceArch != DeviceInfo::UNKNOWN
+        return (deviceArch != DeviceInfo::UNSUPPORTED
                 && !(deviceArch == DeviceInfo::GFX908 && std::is_same<InputT, float64_t>::value));
     }
 

--- a/test/hip_device.hpp
+++ b/test/hip_device.hpp
@@ -39,15 +39,16 @@ namespace rocwmma
     {
     public:
         // For static initialization
-        friend class LazySingleton<HipDevice>;
+        friend std::unique_ptr<HipDevice> std::make_unique<HipDevice>();
+
         enum hipGcnArch_t : uint32_t
         {
             GFX908 = 0x908,
             GFX90A = 0x90A,
-            UNKNOWN,
+            UNSUPPORTED,
         };
 
-    public:
+    protected:
         HipDevice();
 
     public:

--- a/test/unit/unit_kernel_base_impl.hpp
+++ b/test/unit/unit_kernel_base_impl.hpp
@@ -80,7 +80,7 @@ namespace rocwmma
     bool UnitKernelBase<BlockM, BlockN, DataT, Layout>::checkDevice() const
     {
         auto deviceArch = DeviceInfo::instance()->getGcnArch();
-        return (deviceArch != DeviceInfo::UNKNOWN
+        return (deviceArch != DeviceInfo::UNSUPPORTED
                 && !(deviceArch == DeviceInfo::GFX908 && std::is_same<DataT, float64_t>::value));
     }
 


### PR DESCRIPTION
Compile time check to see if the library is run on one of the supported GPUs.

If its not supported, tests and samples are not build and it exits with a message "Non-supported GPUs"
Otherwise, it builds as default.

<Edit: cmillett>
There is a workaround for the core dump - On static init, do a device check before any kernels are loaded by hip runtime. This way we can pre-emptively exit early and and avoid the nasty SIGABRT which is triggering the dump. This will manage our test applications only and will not affect other applications using the API
