### PR TITLE
Workgroup aware tests

### DIFF
--- a/library/include/rocwmma/internal/io_shape.hpp
+++ b/library/include/rocwmma/internal/io_shape.hpp
@@ -99,10 +99,7 @@ namespace rocwmma
             KDim     = BlockK,
 
             MaxVectorWidth = detail::VecWidthTraits<BlockDim, KDim, DataT>::MaxVectorWidth,
-            VectorWidth
-            = (std::is_same<DataLayoutT, row_major>::value && BlockDim < AMDGCN_WAVE_SIZE)
-                  ? MaxVectorWidth
-                  : 1
+            VectorWidth    = std::is_same<DataLayoutT, row_major>::value ? MaxVectorWidth : 1
         };
 
         static_assert(!(std::is_same<DataLayoutT, col_major>::value && VectorWidth > 1),
@@ -162,10 +159,7 @@ namespace rocwmma
             KDim     = BlockK,
 
             MaxVectorWidth = detail::VecWidthTraits<BlockDim, KDim, DataT>::MaxVectorWidth,
-            VectorWidth
-            = (std::is_same<DataLayoutT, col_major>::value && BlockDim < AMDGCN_WAVE_SIZE)
-                  ? MaxVectorWidth
-                  : 1
+            VectorWidth    = std::is_same<DataLayoutT, col_major>::value ? MaxVectorWidth : 1
         };
 
         static_assert(!(std::is_same<DataLayoutT, row_major>::value && VectorWidth > 1),

--- a/test/gemm/CMakeLists.txt
+++ b/test/gemm/CMakeLists.txt
@@ -226,6 +226,7 @@ if(ROCWMMA_BUILD_BENCHMARK_TESTS)
   add_gemm_benchmark_test(barrier_test-bench ${BarrierTestSources})
   add_gemm_benchmark_test(mma_sync_test-bench ${MmaSyncTestSources})
   add_gemm_benchmark_test(mma_sync_multi_test-bench ${MmaSyncMultiTestSources})
+  add_gemm_benchmark_test(mma_sync_coop_wg_test-bench ${MmaSyncCoopWgTestSources})
   add_gemm_benchmark_test(mma_sync_multi_lds_test-bench ${MmaSyncMultiLdsTestSources})
 endif()
 

--- a/test/gemm/CMakeLists.txt
+++ b/test/gemm/CMakeLists.txt
@@ -193,6 +193,29 @@ if(ROCWMMA_BUILD_EXTENDED_TESTS)
                                  )
 endif()
 
+set(MmaSyncCoopWgTestSources ${GemmCommonSources}
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nn_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nt_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tn_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nn_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nt_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tn_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tt_1x1.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nn_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nt_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tn_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nn_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nt_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tn_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tt_2x2.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nn_4x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nt_4x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tn_4x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_4x4.cpp
+			                      )
+
 set(MmaSyncAdHocTestSources ${GemmCommonSources}
     ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_ad_hoc.cpp)
 
@@ -212,5 +235,6 @@ if(ROCWMMA_BUILD_VALIDATION_TESTS)
   add_gemm_validation_test(mma_sync_test-validate ${MmaSyncTestSources})
   add_gemm_validation_test(mma_sync_multi_test-validate ${MmaSyncMultiTestSources})
   add_gemm_validation_test(mma_sync_multi_lds_test-validate ${MmaSyncMultiLdsTestSources})
+  add_gemm_validation_test(mma_sync_coop_wg_test-validate ${MmaSyncCoopWgTestSources})
   add_gemm_validation_test(mma_sync_ad_hoc_test ${MmaSyncAdHocTestSources})
 endif()

--- a/test/gemm/detail/mma_sync_coop_wg.hpp
+++ b/test/gemm/detail/mma_sync_coop_wg.hpp
@@ -1,0 +1,299 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_DETAIL_MMA_SYNC_COOP_WG_HPP
+#define ROCWMMA_DETAIL_MMA_SYNC_COOP_WG_HPP
+
+#include "device/mma_sync_multi_lds.hpp"
+#include "gemm_kernel_base.hpp"
+
+namespace rocwmma
+{
+
+    // Wrapper into the actual device function
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              uint32_t BlockK,
+              typename InputT,
+              typename OutputT,
+              typename ComputeT,
+              typename LayoutA,
+              typename LayoutB,
+              typename LayoutC,
+              typename LayoutD,
+              typename LayoutLds,
+              typename GemmConfig,
+              uint32_t BlocksX = 1,
+              uint32_t BlocksY = 1>
+    struct MmaSyncCoopWgKernel final : public GemmKernelBase<BlockM,
+                                                             BlockN,
+                                                             BlockK,
+                                                             InputT,
+                                                             OutputT,
+                                                             ComputeT,
+                                                             LayoutA,
+                                                             LayoutB,
+                                                             LayoutC,
+                                                             LayoutD>
+    {
+    private:
+        using Base = GemmKernelBase<BlockM,
+                                    BlockN,
+                                    BlockK,
+                                    InputT,
+                                    OutputT,
+                                    ComputeT,
+                                    LayoutA,
+                                    LayoutB,
+                                    LayoutC,
+                                    LayoutD>;
+
+    public:
+        MmaSyncCoopWgKernel() {}
+        ~MmaSyncCoopWgKernel() final {}
+
+        dim3 gridDim() const final
+        {
+            return dim3(ceilDiv(Base::mM, BlockM * BlocksX * Base::mTBlockX / AMDGCN_WAVE_SIZE),
+                        ceilDiv(Base::mN, BlockN * BlocksY * Base::mTBlockY));
+        }
+
+        bool checkSizes() const final
+        {
+            return ((BlockM * BlocksX * Base::mTBlockX / AMDGCN_WAVE_SIZE) <= Base::mM)
+                   && ((BlockN * BlocksY * Base::mTBlockY) <= Base::mN) && (BlockK <= Base::mK);
+        }
+
+        bool checkQuirks() const final
+        {
+            // Don't run the kernel if the threadblock size is not supported
+            return (kernelImpl() != nullptr);
+        }
+
+        // Lds memory usage in bytes
+        uint32_t ldsUsage() const final
+        {
+            // Uses 2 lds blocks for prefetch loop
+            return 2 * sizeof(InputT)
+                   * (Base::mTBlockX / AMDGCN_WAVE_SIZE * BlocksX * BlockM * BlockK
+                      + Base::mTBlockY * BlocksY * BlockK * BlockN);
+        }
+
+        typename Base::KernelFunc kernelImpl() const final
+        {
+            auto kernelFunc = typename Base::KernelFunc(nullptr);
+
+            if(Base::mTBlockX == 64)
+            {
+                if(Base::mTBlockY == 1)
+                {
+                    kernelFunc = typename Base::KernelFunc(mmaSyncMultiLds<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           LayoutLds,
+                                                                           GemmConfig,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           64,
+                                                                           1>);
+                }
+                else if(Base::mTBlockY == 2)
+                {
+                    kernelFunc = typename Base::KernelFunc(mmaSyncMultiLds<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           LayoutLds,
+                                                                           GemmConfig,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           64,
+                                                                           2>);
+                }
+                else if(Base::mTBlockY == 4)
+                {
+                    kernelFunc = typename Base::KernelFunc(mmaSyncMultiLds<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           LayoutLds,
+                                                                           GemmConfig,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           64,
+                                                                           4>);
+                }
+            }
+            else if(Base::mTBlockX == 128)
+            {
+                if(Base::mTBlockY == 1)
+                {
+                    kernelFunc = typename Base::KernelFunc(mmaSyncMultiLds<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           LayoutLds,
+                                                                           GemmConfig,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           128,
+                                                                           1>);
+                }
+                else if(Base::mTBlockY == 2)
+                {
+                    kernelFunc = typename Base::KernelFunc(mmaSyncMultiLds<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           LayoutLds,
+                                                                           GemmConfig,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           128,
+                                                                           2>);
+                }
+            }
+            else if(Base::mTBlockX == 256)
+            {
+                if(Base::mTBlockY == 1)
+                {
+                    kernelFunc = typename Base::KernelFunc(mmaSyncMultiLds<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           LayoutLds,
+                                                                           GemmConfig,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           256,
+                                                                           1>);
+                }
+            }
+
+            return kernelFunc;
+        }
+
+        std::ostream& printHeader(std::ostream& stream = std::cout) const final
+        {
+            return Base::printHeader(stream << "GemmConfig, LytLds, BlocksX, BlocksY, ");
+        }
+
+        std::ostream& printKernel(std::ostream& stream = std::cout) const final
+        {
+            return Base::printKernel(stream << dataTypeToString<GemmConfig>() << ", "
+                                            << dataTypeToString<LayoutLds>() << ", " << BlocksX
+                                            << ", " << BlocksY << ", ");
+        }
+    };
+
+    // This is the GeneratorImpl class for MmaSyncCoopLds
+    struct MmaSyncCoopWgGenerator
+    {
+        // Indices to test parameters
+        enum : uint32_t
+        {
+            InputT     = 0,
+            OutputT    = 1,
+            ComputeT   = 2,
+            BlockM     = 3,
+            BlockN     = 4,
+            BlockK     = 5,
+            LayoutA    = 6,
+            LayoutB    = 7,
+            LayoutCD   = 8,
+            LayoutLds  = 9,
+            GemmConfig = 10,
+            BlocksX    = 11,
+            BlocksY    = 12
+        };
+
+        using ResultT = std::shared_ptr<KernelI>;
+
+        template <typename... Ts>
+        static ResultT generate(std::tuple<Ts...> testParams)
+        {
+            using TestParamsT = std::tuple<Ts...>;
+            using KernelT
+                = MmaSyncCoopWgKernel<std::tuple_element_t<BlockM, TestParamsT>::value, // BlockM
+                                      std::tuple_element_t<BlockN, TestParamsT>::value, // BlockN
+                                      std::tuple_element_t<BlockK, TestParamsT>::value, // BlockK
+                                      std::tuple_element_t<InputT, TestParamsT>, // InputT
+                                      std::tuple_element_t<OutputT, TestParamsT>, // OutputT
+                                      std::tuple_element_t<ComputeT, TestParamsT>, // ComputeT
+                                      std::tuple_element_t<LayoutA, TestParamsT>, // LayoutA
+                                      std::tuple_element_t<LayoutB, TestParamsT>, // LayoutB
+                                      std::tuple_element_t<LayoutCD, TestParamsT>, // LayoutC
+                                      std::tuple_element_t<LayoutCD, TestParamsT>, // LayoutD
+                                      std::tuple_element_t<LayoutLds, TestParamsT>, // LayoutLds
+                                      std::tuple_element_t<GemmConfig, TestParamsT>, // LayoutLds
+                                      std::tuple_element_t<BlocksX, TestParamsT>::value, // BlocksX
+                                      std::tuple_element_t<BlocksY, TestParamsT>::value // BlocksY
+                                      >;
+
+            return std::make_shared<KernelT>();
+        }
+    };
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_DETAIL_MMA_SYNC_COOP_WG_HPP

--- a/test/gemm/device/mma_sync_multi_lds.hpp
+++ b/test/gemm/device/mma_sync_multi_lds.hpp
@@ -59,7 +59,9 @@ namespace rocwmma
               typename LayoutLds,
               typename GemmConfig,
               uint32_t BlocksX = 1,
-              uint32_t BlocksY = 1>
+              uint32_t BlocksY = 1,
+              uint32_t TBlockX = 0,
+              uint32_t TBlockY = 0>
     __global__ void __launch_bounds__(256) mmaSyncMultiLds(uint32_t       m,
                                                            uint32_t       n,
                                                            uint32_t       k,
@@ -88,14 +90,15 @@ namespace rocwmma
                                                                           LayoutC,
                                                                           LayoutD,
                                                                           BlocksX,
-                                                                          BlocksY>;
+                                                                          BlocksY,
+                                                                          TBlockX,
+                                                                          TBlockY>;
 
-        using LdsMapping = typename GemmConfig::template LdsMapping<GlobalMapping, LayoutLds>;
-        using GemmDriver = typename GemmConfig::template GemmDriver<
-            GlobalMapping,
-            LdsMapping,
-            typename GemmConfig::template CoopSchedulerA<>,
-            typename GemmConfig::template CoopSchedulerB<>>;
+        using LdsMapping     = typename GemmConfig::template LdsMapping<GlobalMapping, LayoutLds>;
+        using CoopSchedulerA = typename GemmConfig::template CoopSchedulerA<TBlockX, TBlockY>;
+        using CoopSchedulerB = typename GemmConfig::template CoopSchedulerB<TBlockX, TBlockY>;
+        using GemmDriver     = typename GemmConfig::
+            template GemmDriver<GlobalMapping, LdsMapping, CoopSchedulerA, CoopSchedulerB>;
 
         // Global fragments used in pre-fetching
         using GRFragA = typename GlobalMapping::GRFragA;

--- a/test/gemm/gemm_config.hpp
+++ b/test/gemm/gemm_config.hpp
@@ -289,6 +289,106 @@ namespace rocwmma
 
         } // namespace WaveLevel
 
+        namespace WorkgroupLevel
+        {
+            struct LdsNT
+            {
+                template <uint32_t BlockM,
+                          uint32_t BlockN,
+                          uint32_t BlockK,
+                          typename InputT,
+                          typename OutputT,
+                          typename ComputeT,
+                          typename LayoutA,
+                          typename LayoutB,
+                          typename LayoutC,
+                          typename LayoutD,
+                          uint32_t BlocksX,
+                          uint32_t BlocksY,
+                          uint32_t TBlockX,
+                          uint32_t TBlockY>
+                using GlobalMapping = GlobalMapping::WorkgroupLevelMapping<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           TBlockX,
+                                                                           TBlockY>;
+
+                template <typename GlobalMapping, typename LayoutLds>
+                using LdsMapping = LocalMapping::LdsMappingNT<GlobalMapping, LayoutLds>;
+
+                template <uint32_t TBlockX, uint32_t TBlockY>
+                using CoopSchedulerA = typename Schedule::AllRowMajor<TBlockX, TBlockY>;
+
+                template <uint32_t TBlockX, uint32_t TBlockY>
+                using CoopSchedulerB = typename Schedule::AllRowMajor<TBlockX, TBlockY>;
+
+                template <typename GlobalMapping,
+                          typename LdsMapping,
+                          typename CoopSchedulerA,
+                          typename CoopSchedulerB>
+                using GemmDriver
+                    = GemmDriver<GlobalMapping, LdsMapping, CoopSchedulerA, CoopSchedulerB>;
+            };
+
+            struct LdsTN
+            {
+                template <uint32_t BlockM,
+                          uint32_t BlockN,
+                          uint32_t BlockK,
+                          typename InputT,
+                          typename OutputT,
+                          typename ComputeT,
+                          typename LayoutA,
+                          typename LayoutB,
+                          typename LayoutC,
+                          typename LayoutD,
+                          uint32_t BlocksX,
+                          uint32_t BlocksY,
+                          uint32_t TBlockX,
+                          uint32_t TBlockY>
+                using GlobalMapping = GlobalMapping::WorkgroupLevelMapping<BlockM,
+                                                                           BlockN,
+                                                                           BlockK,
+                                                                           InputT,
+                                                                           OutputT,
+                                                                           ComputeT,
+                                                                           LayoutA,
+                                                                           LayoutB,
+                                                                           LayoutC,
+                                                                           LayoutD,
+                                                                           BlocksX,
+                                                                           BlocksY,
+                                                                           TBlockX,
+                                                                           TBlockY>;
+
+                template <typename GlobalMapping, typename LayoutLds>
+                using LdsMapping = LocalMapping::LdsMappingTN<GlobalMapping, LayoutLds>;
+
+                template <uint32_t TBlockX, uint32_t TBlockY>
+                using CoopSchedulerA = typename Schedule::AllRowMajor<TBlockX, TBlockY>;
+
+                template <uint32_t TBlockX, uint32_t TBlockY>
+                using CoopSchedulerB = typename Schedule::AllRowMajor<TBlockX, TBlockY>;
+
+                template <typename GlobalMapping,
+                          typename LdsMapping,
+                          typename CoopSchedulerA,
+                          typename CoopSchedulerB>
+                using GemmDriver
+                    = GemmDriver<GlobalMapping, LdsMapping, CoopSchedulerA, CoopSchedulerB>;
+            };
+
+        } // namespace WorkgroupLevel
+
     } // namespace CooperativeGemm
 
     template <>
@@ -319,6 +419,18 @@ namespace rocwmma
     constexpr const char* dataTypeToString<typename CooperativeGemm::WaveLevel::LdsTN>()
     {
         return "Wave_LdsTN";
+    }
+
+    template <>
+    constexpr const char* dataTypeToString<typename CooperativeGemm::WorkgroupLevel::LdsNT>()
+    {
+        return "Workgroup_LdsNT";
+    }
+
+    template <>
+    constexpr const char* dataTypeToString<typename CooperativeGemm::WorkgroupLevel::LdsTN>()
+    {
+        return "Workgroup_LdsTN";
     }
 
 } // namespace rocwmma

--- a/test/gemm/gemm_global_mapping.hpp
+++ b/test/gemm/gemm_global_mapping.hpp
@@ -306,6 +306,8 @@ namespace rocwmma
             * This global read A/B fragments are not MFMA friendly, however when written to LDS
             * smaller MFMA friendly fragment may be read directly from the same LDS layout.
             * Larger GR may be more efficient in certain layouts for data pipelining.
+            *
+            * This layout can accommodate either compile time or runtime TBlockX/Y params.
             */
             using Base = detail::MappingBase<BlockM,
                                              BlockN,
@@ -376,8 +378,8 @@ namespace rocwmma
                   typename LayoutD,
                   uint32_t BlocksX,
                   uint32_t BlocksY,
-                  uint32_t TBlockX = 0,
-                  uint32_t TBlockY = 0>
+                  uint32_t TBlockX,
+                  uint32_t TBlockY>
         struct WorkgroupLevelMapping : public detail::MappingBase<BlockM,
                                                                   BlockN,
                                                                   BlockK,
@@ -393,6 +395,12 @@ namespace rocwmma
                                                                   TBlockX,
                                                                   TBlockY>
         {
+
+            // Must provide valid TBlockX/Y params at compile time.
+            static_assert((TBlockX > 0) && (TBlockX % AMDGCN_WAVE_SIZE == 0),
+                          "Invalid TBlockX dimension");
+            static_assert(TBlockY > 0, "Invalid TBlockY dimension");
+
             /*
             * This flavour of Global Mapping targets A/B as a single macro tile sized fragment.
             * C/D wave tiles are targeted iteratively in MFMA fragment chunks:

--- a/test/gemm/test/common_test_params.hpp
+++ b/test/gemm/test/common_test_params.hpp
@@ -55,6 +55,13 @@ namespace rocwmma
 
         } // namespace WaveLevel
 
+        namespace WorkgroupLevel
+        {
+            class LdsNT;
+            class LdsTN;
+
+        } // namespace WaveLevel
+
     } // namespace CooperativeGemm
 
     struct CommonTestParams
@@ -122,6 +129,12 @@ namespace rocwmma
 #endif // ROCWMMA_EXTENDED_TESTS \
     // Benchmark only wave-level as they are more performant
             std::tuple<typename CooperativeGemm::WaveLevel::LdsTN>>;
+
+        using TestGemmConfigsWgLevel = std::tuple<
+#if defined(ROCWMMA_VALIDATION_TESTS) || defined(ROCWMMA_EXTENDED_TESTS)
+            std::tuple<typename CooperativeGemm::WorkgroupLevel::LdsNT>,
+#endif // ROCWMMA_EXTENDED_TESTS
+            std::tuple<typename CooperativeGemm::WorkgroupLevel::LdsTN>>;
 
         ///
         /// Grouped compile time kernel parameters

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_1x1.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NN
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NN1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NN1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NN1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_2x2.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NN
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NN2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NN2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NN2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NN
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NN4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NN4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NN4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_1x1.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NT
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NT1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NT1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NT1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_2x2.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NT
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NT2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NT2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NT2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NT
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NT4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NT4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NT4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_1x1.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TN
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TN1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TN1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TN1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_2x2.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TN
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TN2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TN2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TN2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TN
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TN4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TN4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TN4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_1x1.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TT
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TT1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TT1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TT1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_2x2.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TT
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TT2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TT2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TT2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TT
+        using Types = typename Base::TestTypesIOC;
+        using BlockSizes
+            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TT4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TT4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TT4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_1x1.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: NN
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32NN1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32NN1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32NN1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_2x2.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: NN
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32NN2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32NN2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32NN2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_1x1.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: NT
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32NT1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32NT1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32NT1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_2x2.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: NT
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32NT2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32NT2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32NT2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_1x1.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: TN
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32TN1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32TN1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32TN1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_2x2.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: TN
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32TN2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32TN2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32TN2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_1x1.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: TT
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<1>, I<1>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32TT1x1 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32TT1x1, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32TT1x1,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_2x2.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: TT
+        using Types       = typename Base::TestTypes32x32;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
+                                      std::tuple<I<32>, I<32>, I<16>>,
+                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<2>, I<2>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32TT2x2 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32TT2x2, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32TT2x2,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));


### PR DESCRIPTION
Adding barrage of tests for workgroup aware kernels:
- validation 
- extended
- benchmark


Depends on [PR-39](https://github.com/ROCmSoftwarePlatform/rocWMMA/pull/39)