### PR TITLE
Coop Load / Store performance enhancement on wg kernels

### DIFF
--- a/library/include/rocwmma/internal/coop_load.hpp
+++ b/library/include/rocwmma/internal/coop_load.hpp
@@ -107,6 +107,55 @@ namespace rocwmma
                 ioIter += workItemIOInc;
             }
         }
+
+        template <uint32_t WaveCount, uint32_t SplitCount>
+        __device__ static inline void exec(typename Traits::OutputT& data,
+                                           DataT const*              dataPtr,
+                                           uint32_t                  ldm,
+                                           uint32_t                  waveIndex)
+        {
+            // Ensure that splitCount doesn't exceed our maximum
+            constexpr auto splitCount = std::min(SplitCount, (uint32_t)Traits::MaxSplit);
+
+            // For the cases where there are more waves than splits.
+            if(waveIndex >= splitCount)
+                return;
+
+            // Calculate the number of 'work items' for the current wave,
+            // as well as the IOCount per work item.
+            // NOTE: If there are in fact more waves than work items, make sure there
+            // is at least one work item per wave. Waves that can't contribute will be
+            // filtered out by the above check.
+            constexpr auto workItemCount   = std::max(splitCount / WaveCount, 1u);
+            constexpr auto workItemIOCount = IOTraits::IOCount / splitCount;
+
+            // Calculate the current wave's starting IO iterator index for the first work item.
+            // Calculate the IO offset between work items for the current wave.
+            auto& reducedFt = reinterpret_cast<
+                VecT<DataT, workItemCount * workItemIOCount * Traits::LoadT::size()>&>(data);
+            auto ioIter = reducedFt.template begin<Traits::LoadT::size()>();
+
+            // Align threads to starting matrix offset coordinates
+            auto baseOffset = MatrixLayout::baseOffset();
+
+            // Iterate through the work items for this wave only.
+            // Both loops may get unrolled if splitCount and waveCount are known at compile time.
+#pragma unroll
+            for(uint32_t i = 0; i < workItemCount; i++)
+            {
+                auto cumOffset = (i * WaveCount + waveIndex) * workItemIOCount;
+#pragma unroll
+                for(uint32_t j = 0; j < workItemIOCount; ++j)
+                {
+                    Traits::Loader::exec(
+                        *ioIter,
+                        dataPtr,
+                        DataLayout::fromMatrixCoord(
+                            baseOffset + MatrixLayout::cumulativeOffset(cumOffset++), ldm));
+                    ioIter++;
+                }
+            }
+        }
     };
 
 } // namespace rocwmma

--- a/test/gemm/CMakeLists.txt
+++ b/test/gemm/CMakeLists.txt
@@ -216,6 +216,19 @@ set(MmaSyncCoopWgTestSources ${GemmCommonSources}
                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_4x4.cpp
 			                      )
 
+if(ROCWMMA_BUILD_EXTENDED_TESTS)
+set(MmaSyncCoopWgTestSources ${MmaSyncMultiLdsTestSources}
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nn_8x8.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nt_8x8.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tn_8x8.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_8x8.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nn_4x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nt_4x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tn_4x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tt_4x4.cpp
+                                )
+endif()
+
 set(MmaSyncAdHocTestSources ${GemmCommonSources}
     ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_ad_hoc.cpp)
 

--- a/test/gemm/gemm_coop_schedule.hpp
+++ b/test/gemm/gemm_coop_schedule.hpp
@@ -126,6 +126,23 @@ namespace rocwmma
                 }
             };
 
+            template <class Schedule>
+            struct WaveCountIsConstexpr;
+
+            // Schedule with non-zero TBlockX/Y values has constexpr waveCount();
+            template <template <uint32_t, uint32_t> class Schedule,
+                      uint32_t TBlockX,
+                      uint32_t TBlockY>
+            struct WaveCountIsConstexpr<Schedule<TBlockX, TBlockY>> : public std::true_type
+            {
+            };
+
+            // Schedule with TBlockX/Y = (0,0) values does not have constexpr waveCount();
+            template <template <uint32_t, uint32_t> class Schedule>
+            struct WaveCountIsConstexpr<Schedule<0u, 0u>> : public std::false_type
+            {
+            };
+
         } // namespace Schedule
 
     } // namespace CooperativeGemm

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_8x8.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_8x8.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NN
+        using Types       = typename Base::TestTypesIOC;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NN8x8 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NN8x8, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NN8x8,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_8x8.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_8x8.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: NT
+        using Types       = typename Base::TestTypesIOC;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16NT8x8 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16NT8x8, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16NT8x8,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_8x8.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_8x8.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TN
+        using Types       = typename Base::TestTypesIOC;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TN8x8 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TN8x8, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TN8x8,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_8x8.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_8x8.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 16 x 16 x BlockK
+        // Layouts: TT
+        using Types       = typename Base::TestTypesIOC;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest16x16TT8x8 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest16x16TT8x8, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest16x16TT8x8,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: NN
+        using Types = typename Base::TestTypes32x32;
+        using BlockSizes
+            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsNN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32NN4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32NN4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32NN4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: NT
+        using Types = typename Base::TestTypes32x32;
+        using BlockSizes
+            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsNT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32NT4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32NT4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32NT4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: TN
+        using Types = typename Base::TestTypes32x32;
+        using BlockSizes
+            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsTN;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32TN4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32TN4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32TN4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_4x4.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <type_traits>
+
+#include "detail/mma_sync_coop_wg.hpp"
+#include "gemm_config.hpp"
+#include "gemm_test.hpp"
+#include "kernel_generator.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public CommonTestParams
+    {
+        using Base = CommonTestParams;
+
+        // Types: ALL + double
+        // Block Sizes: 32 x 32 x BlockK
+        // Layouts: TT
+        using Types = typename Base::TestTypes32x32;
+        using BlockSizes
+            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Layouts     = typename Base::TestLayoutsTT;
+        using LayoutsLds  = typename Base::TestLdsLayoutTypes;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
+        using KernelParams =
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+                Result;
+
+        // Assemble the kernel generator
+        // Kernel: MmaSyncMulti
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class MmaSyncCoopWgTest32x32TT4x4 : public rocwmma::GemmTest
+{
+};
+
+TEST_P(MmaSyncCoopWgTest32x32TT4x4, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GemmKernelTests,
+    MmaSyncCoopWgTest32x32TT4x4,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::alphas()),
+                       ::testing::ValuesIn(rocwmma::TestParams::betas())));


### PR DESCRIPTION
Added a coop load / store function that accepts WaveCount and SplitCount as explicit compile time parameters.

Having these two values as compile time params has several benefits:
- Avoids expensive integer division
- fully compatible with pragma unroll
- We can reinterpret fragments to smaller size that are only as big as the cooperative coverage (not the entire fragment)
- Much higher odds to inline code, increasing performance.

In order to get this to work and ensure compatibility between wave and wg level kernels, a coop api selector class was implemented in the driver. This ensures that compile time template params are used where available, and runtime params otherwise.
