### PR TITLE
Update test coverage

### DIFF
--- a/test/gemm/CMakeLists.txt
+++ b/test/gemm/CMakeLists.txt
@@ -134,10 +134,6 @@ if(ROCWMMA_BUILD_EXTENDED_TESTS)
                               ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_32x32_nt_4x4.cpp
                               ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_32x32_tn_4x4.cpp
                               ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_32x32_tt_4x4.cpp
-                              #${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_16x16_nn_8x8.cpp
-                              #${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_16x16_nt_8x8.cpp
-                              #${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_16x16_tn_8x8.cpp
-                              #${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_test_16x16_tt_8x8.cpp
                               )
 endif()
 
@@ -182,14 +178,19 @@ if(ROCWMMA_BUILD_EXTENDED_TESTS)
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_tn_2x1.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_tt_1x2.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_tt_2x1.cpp
+                                 )
+endif()
+
+if(ROCWMMA_BUILD_EXTENDED_TESTS)
+  set(MmaSyncMultiLdsTestSources ${MmaSyncMultiLdsTestSources}
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_nn_8x4.cpp
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_nt_8x4.cpp
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_tn_8x4.cpp
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_tt_8x4.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_nn_4x4.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_nt_4x4.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
                                  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_32x32_tt_4x4.cpp
-                                #  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_nn_8x8.cpp
-                                #  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_nt_8x8.cpp
-                                #  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_tn_8x8.cpp
-                                #  ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_multi_lds_test_16x16_tt_8x8.cpp
                                  )
 endif()
 
@@ -217,11 +218,11 @@ set(MmaSyncCoopWgTestSources ${GemmCommonSources}
 			                      )
 
 if(ROCWMMA_BUILD_EXTENDED_TESTS)
-set(MmaSyncCoopWgTestSources ${MmaSyncMultiLdsTestSources}
-                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nn_8x8.cpp
-                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nt_8x8.cpp
-                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tn_8x8.cpp
-                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_8x8.cpp
+  set(MmaSyncCoopWgTestSources ${MmaSyncCoopWgTestSources}
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nn_8x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_nt_8x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tn_8x4.cpp
+                                ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_16x16_tt_8x4.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nn_4x4.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_nt_4x4.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/test/mma_sync_coop_wg_test_32x32_tn_4x4.cpp

--- a/test/gemm/device/mma_sync_multi_lds.hpp
+++ b/test/gemm/device/mma_sync_multi_lds.hpp
@@ -234,7 +234,7 @@ namespace rocwmma
         }
         else
         {
-            GemmDriver::fill(fragsC, 0);
+            GemmDriver::fill(fragsC, static_cast<OutputT>(0));
         }
 
         ///

--- a/test/gemm/test/common_test_params.hpp
+++ b/test/gemm/test/common_test_params.hpp
@@ -72,7 +72,7 @@ namespace rocwmma
         ///
 
         // Testing types as Input/Output/Compute (IOC)
-        using TestTypesIOC = std::tuple<
+        using TestTypesSmall = std::tuple<
         // Non-native bfloat16_t
 
 #if defined(ROCWMMA_EXTENDED_TESTS)
@@ -88,9 +88,6 @@ namespace rocwmma
 #endif // ROCWMMA_EXTENDED_TESTS
             std::tuple<float16_t, float32_t, float32_t>,
 
-            // Native fp32
-            std::tuple<float32_t, float32_t, float32_t>,
-
         // Non-native hfloat16_t (i.e. __half)
 #if defined(ROCWMMA_EXTENDED_TESTS)
             std::tuple<hfloat16_t, hfloat16_t, hfloat16_t>,
@@ -104,7 +101,10 @@ namespace rocwmma
 #endif // ROCWMMA_EXTENDED_TESTS
             std::tuple<int8_t, int32_t, int32_t>>;
 
-        // Native double
+        // Native single f32
+        using TestTypeSingle = std::tuple<std::tuple<float32_t, float32_t, float32_t>>;
+
+        // Native double f64
         using TestTypeDouble = std::tuple<std::tuple<float64_t, float64_t, float64_t>>;
 
         // Supported layout types
@@ -139,6 +139,9 @@ namespace rocwmma
         ///
         /// Grouped compile time kernel parameters
         ///
+
+        // Default base set of types to test
+        using TestTypesIOC = typename Concat<TestTypesSmall, TestTypeSingle>::Result;
 
         // 16 x 16 has support for double types
         using TestTypes16x16 = typename Concat<TestTypesIOC, TestTypeDouble>::Result;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_8x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nn_8x4.cpp
@@ -38,15 +38,15 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small types
         // Block Sizes: 16 x 16 x BlockK
-        // Layouts: NT
-        using Types       = typename Base::TestTypesIOC;
+        // Layouts: NN
+        using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
-        using Layouts     = typename Base::TestLayoutsNT;
+        using Layouts     = typename Base::TestLayoutsNN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
             typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
                 Result;
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncCoopWgTest16x16NT8x8 : public rocwmma::GemmTest
+class MmaSyncCoopWgTest16x16NN8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncCoopWgTest16x16NT8x8, RunKernel)
+TEST_P(MmaSyncCoopWgTest16x16NN8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncCoopWgTest16x16NT8x8,
+    MmaSyncCoopWgTest16x16NN8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_8x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_nt_8x4.cpp
@@ -26,7 +26,7 @@
 
 #include <type_traits>
 
-#include "detail/mma_sync_multi_lds.hpp"
+#include "detail/mma_sync_coop_wg.hpp"
 #include "gemm_config.hpp"
 #include "gemm_test.hpp"
 #include "kernel_generator.hpp"
@@ -40,20 +40,20 @@ namespace rocwmma
 
         // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
-        // Layouts: TT
+        // Layouts: NT
         using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
-        using Layouts     = typename Base::TestLayoutsTT;
+        using Layouts     = typename Base::TestLayoutsNT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
-        using MappingsLds = typename Base::TestMappingsLds;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
-            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
                 Result;
 
         // Assemble the kernel generator
         // Kernel: MmaSyncMulti
-        using GeneratorImpl   = MmaSyncMultiLdsGenerator;
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncMultiLdsTest16x16TT8x8 : public rocwmma::GemmTest
+class MmaSyncCoopWgTest16x16NT8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncMultiLdsTest16x16TT8x8, RunKernel)
+TEST_P(MmaSyncCoopWgTest16x16NT8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncMultiLdsTest16x16TT8x8,
+    MmaSyncCoopWgTest16x16NT8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_8x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tn_8x4.cpp
@@ -26,7 +26,7 @@
 
 #include <type_traits>
 
-#include "detail/mma_sync_multi_lds.hpp"
+#include "detail/mma_sync_coop_wg.hpp"
 #include "gemm_config.hpp"
 #include "gemm_test.hpp"
 #include "kernel_generator.hpp"
@@ -38,22 +38,22 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: Small sizes
+        // Types: Small types
         // Block Sizes: 16 x 16 x BlockK
-        // Layouts: NT
+        // Layouts: TN
         using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
-        using Layouts     = typename Base::TestLayoutsNT;
+        using Layouts     = typename Base::TestLayoutsTN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
-        using MappingsLds = typename Base::TestMappingsLds;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
-            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
                 Result;
 
         // Assemble the kernel generator
         // Kernel: MmaSyncMulti
-        using GeneratorImpl   = MmaSyncMultiLdsGenerator;
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncMultiLdsTest16x16NT8x8 : public rocwmma::GemmTest
+class MmaSyncCoopWgTest16x16TN8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncMultiLdsTest16x16NT8x8, RunKernel)
+TEST_P(MmaSyncCoopWgTest16x16TN8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncMultiLdsTest16x16NT8x8,
+    MmaSyncCoopWgTest16x16TN8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_8x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_16x16_tt_8x4.cpp
@@ -26,7 +26,7 @@
 
 #include <type_traits>
 
-#include "detail/mma_sync_multi_lds.hpp"
+#include "detail/mma_sync_coop_wg.hpp"
 #include "gemm_config.hpp"
 #include "gemm_test.hpp"
 #include "kernel_generator.hpp"
@@ -38,22 +38,22 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: Small sizes
+        // Types: Small types
         // Block Sizes: 16 x 16 x BlockK
-        // Layouts: NN
+        // Layouts: TT
         using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
-        using Layouts     = typename Base::TestLayoutsNN;
+        using Layouts     = typename Base::TestLayoutsTT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
-        using MappingsLds = typename Base::TestMappingsLds;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
-            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
                 Result;
 
         // Assemble the kernel generator
         // Kernel: MmaSyncMulti
-        using GeneratorImpl   = MmaSyncMultiLdsGenerator;
+        using GeneratorImpl   = MmaSyncCoopWgGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncMultiLdsTest16x16NN8x8 : public rocwmma::GemmTest
+class MmaSyncCoopWgTest16x16TT8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncMultiLdsTest16x16NN8x8, RunKernel)
+TEST_P(MmaSyncCoopWgTest16x16TT8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncMultiLdsTest16x16NN8x8,
+    MmaSyncCoopWgTest16x16TT8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_1x1.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NN
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_2x2.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NN
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nn_4x4.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small types
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes32x32;
-        using BlockSizes
-            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsNN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using GemmConfigs = typename Base::TestGemmConfigsWgLevel;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_1x1.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NT
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_2x2.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NT
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_nt_4x4.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small types
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes32x32;
-        using BlockSizes
-            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsNT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using GemmConfigs = typename Base::TestGemmConfigsWgLevel;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_1x1.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TN
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_2x2.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TN
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tn_4x4.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small types
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes32x32;
-        using BlockSizes
-            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsTN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using GemmConfigs = typename Base::TestGemmConfigsWgLevel;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_1x1.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_1x1.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TT
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_2x2.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_2x2.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: ALL
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TT
         using Types       = typename Base::TestTypes32x32;

--- a/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_coop_wg_test_32x32_tt_4x4.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small types
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes32x32;
-        using BlockSizes
-            = std::tuple<std::tuple<I<32>, I<32>, I<8>>, std::tuple<I<32>, I<32>, I<16>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsTT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using GemmConfigs = typename Base::TestGemmConfigsWgLevel;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_8x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_8x4.cpp
@@ -26,7 +26,7 @@
 
 #include <type_traits>
 
-#include "detail/mma_sync_coop_wg.hpp"
+#include "detail/mma_sync_multi_lds.hpp"
 #include "gemm_config.hpp"
 #include "gemm_test.hpp"
 #include "kernel_generator.hpp"
@@ -38,22 +38,22 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
-        // Layouts: TN
-        using Types       = typename Base::TestTypesIOC;
+        // Layouts: NN
+        using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
-        using Layouts     = typename Base::TestLayoutsTN;
+        using Layouts     = typename Base::TestLayoutsNN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
-        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using MappingsLds = typename Base::TestMappingsLds;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
-            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
                 Result;
 
         // Assemble the kernel generator
         // Kernel: MmaSyncMulti
-        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using GeneratorImpl   = MmaSyncMultiLdsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncCoopWgTest16x16TN8x8 : public rocwmma::GemmTest
+class MmaSyncMultiLdsTest16x16NN8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncCoopWgTest16x16TN8x8, RunKernel)
+TEST_P(MmaSyncMultiLdsTest16x16NN8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncCoopWgTest16x16TN8x8,
+    MmaSyncMultiLdsTest16x16NN8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_8x8.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypesIOC;
-        using BlockSizes
-            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
         using Layouts     = typename Base::TestLayoutsNN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_8x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_8x4.cpp
@@ -26,7 +26,7 @@
 
 #include <type_traits>
 
-#include "detail/mma_sync_coop_wg.hpp"
+#include "detail/mma_sync_multi_lds.hpp"
 #include "gemm_config.hpp"
 #include "gemm_test.hpp"
 #include "kernel_generator.hpp"
@@ -38,22 +38,22 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
-        // Layouts: NN
-        using Types       = typename Base::TestTypesIOC;
+        // Layouts: NT
+        using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
-        using Layouts     = typename Base::TestLayoutsNN;
+        using Layouts     = typename Base::TestLayoutsNT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
-        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using MappingsLds = typename Base::TestMappingsLds;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
-            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
                 Result;
 
         // Assemble the kernel generator
         // Kernel: MmaSyncMulti
-        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using GeneratorImpl   = MmaSyncMultiLdsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncCoopWgTest16x16NN8x8 : public rocwmma::GemmTest
+class MmaSyncMultiLdsTest16x16NT8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncCoopWgTest16x16NN8x8, RunKernel)
+TEST_P(MmaSyncMultiLdsTest16x16NT8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncCoopWgTest16x16NN8x8,
+    MmaSyncMultiLdsTest16x16NT8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_8x8.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypesIOC;
-        using BlockSizes
-            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
         using Layouts     = typename Base::TestLayoutsNT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_8x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_8x4.cpp
@@ -46,7 +46,7 @@ namespace rocwmma
         using Layouts     = typename Base::TestLayoutsTN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
             typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
                 Result;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_8x8.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypesIOC;
-        using BlockSizes
-            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
         using Layouts     = typename Base::TestLayoutsTN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
+        using Types = typename Base::TestTypes16x16;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_8x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_8x4.cpp
@@ -26,7 +26,7 @@
 
 #include <type_traits>
 
-#include "detail/mma_sync_coop_wg.hpp"
+#include "detail/mma_sync_multi_lds.hpp"
 #include "gemm_config.hpp"
 #include "gemm_test.hpp"
 #include "kernel_generator.hpp"
@@ -38,22 +38,22 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types       = typename Base::TestTypesIOC;
+        using Types       = typename Base::TestTypesSmall;
         using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
         using Layouts     = typename Base::TestLayoutsTT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
-        using GemmConfigs = typename Base::TestGemmConfigsWgLevel;
-        using BlocksXY    = std::tuple<std::tuple<I<8>, I<8>>>;
+        using MappingsLds = typename Base::TestMappingsLds;
+        using BlocksXY    = std::tuple<std::tuple<I<8>, I<4>>>;
         using KernelParams =
-            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, GemmConfigs, BlocksXY>::
+            typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
                 Result;
 
         // Assemble the kernel generator
         // Kernel: MmaSyncMulti
-        using GeneratorImpl   = MmaSyncCoopWgGenerator;
+        using GeneratorImpl   = MmaSyncMultiLdsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -69,18 +69,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class MmaSyncCoopWgTest16x16TT8x8 : public rocwmma::GemmTest
+class MmaSyncMultiLdsTest16x16TT8x8 : public rocwmma::GemmTest
 {
 };
 
-TEST_P(MmaSyncCoopWgTest16x16TT8x8, RunKernel)
+TEST_P(MmaSyncMultiLdsTest16x16TT8x8, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     GemmKernelTests,
-    MmaSyncCoopWgTest16x16TT8x8,
+    MmaSyncMultiLdsTest16x16TT8x8,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_8x8.cpp
@@ -38,12 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypesIOC;
-        using BlockSizes
-            = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<16>, I<16>, I<16>>>;
         using Layouts     = typename Base::TestLayoutsTT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_32x32_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_32x32_nn_4x4.cpp
@@ -38,13 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NN
-        using Types       = typename Base::TestTypes32x32;
-        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
-                                      std::tuple<I<32>, I<32>, I<16>>,
-                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsNN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_32x32_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_32x32_nt_4x4.cpp
@@ -38,13 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: NT
-        using Types       = typename Base::TestTypes32x32;
-        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
-                                      std::tuple<I<32>, I<32>, I<16>>,
-                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsNT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
@@ -38,13 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TN
-        using Types       = typename Base::TestTypes32x32;
-        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
-                                      std::tuple<I<32>, I<32>, I<16>>,
-                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsTN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;

--- a/test/gemm/test/mma_sync_multi_lds_test_32x32_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_32x32_tt_4x4.cpp
@@ -38,13 +38,11 @@ namespace rocwmma
     {
         using Base = CommonTestParams;
 
-        // Types: ALL + double
+        // Types: Small sizes
         // Block Sizes: 32 x 32 x BlockK
         // Layouts: TT
-        using Types       = typename Base::TestTypes32x32;
-        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>,
-                                      std::tuple<I<32>, I<32>, I<16>>,
-                                      std::tuple<I<32>, I<32>, I<32>>>;
+        using Types       = typename Base::TestTypesSmall;
+        using BlockSizes  = std::tuple<std::tuple<I<32>, I<32>, I<8>>>;
         using Layouts     = typename Base::TestLayoutsTT;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;


### PR DESCRIPTION
- Fix compile errors
- Update the basic test coverage for multi-lds and coop-wg
- Update extended test coverage for multi-lds and coop-wg
- Reserve macro tile sizes of 256+ to fp16 and smaller sizes. (i.e usage of TestSizesSmall in common params)
- Ensure builds are successful with ROCWMMA_BUILD_EXTENDED_TESTS=ON and ROCWMMA_BUILD_BENCHMARK_TESTS=ON
- Basic validation on MI-100 (pass/fail)
- Basic validation on MI-200 (pass/fail)