### PR TITLE
Disable 4x4 tests for fp64

### DIFF
--- a/test/gemm/detail/mma_sync_coop_wg.hpp
+++ b/test/gemm/detail/mma_sync_coop_wg.hpp
@@ -94,8 +94,8 @@ namespace rocwmma
 
             // TODO: Fp64 fails validation for BlockK > 16 for 16 x 16.
             auto fp64Check16x16
-                = !(std::is_same<InputT, float64_t>::value && (BlockM == BlockN == 16)
-                    && (BlocksX * BlocksY >= 16) && (BlockK > 16));
+                = !(std::is_same<InputT, float64_t>::value && (BlockM == 16) && (BlockN == 16)
+                    && (BlockK > 16) && (BlocksX * BlocksY >= 16));
 
             return Base::checkQuirks() && kernelImplCheck && fp64Check16x16;
         }

--- a/test/gemm/detail/mma_sync_coop_wg.hpp
+++ b/test/gemm/detail/mma_sync_coop_wg.hpp
@@ -90,7 +90,14 @@ namespace rocwmma
         bool checkQuirks() const final
         {
             // Don't run the kernel if the threadblock size is not supported
-            return (kernelImpl() != nullptr);
+            auto kernelImplCheck = (kernelImpl() != nullptr);
+
+            // TODO: Fp64 fails validation for BlockK > 16 for 16 x 16.
+            auto fp64Check16x16
+                = !(std::is_same<InputT, float64_t>::value && (BlockM == BlockN == 16)
+                    && (BlocksX * BlocksY >= 16) && (BlockK > 16));
+
+            return Base::checkQuirks() && kernelImplCheck && fp64Check16x16;
         }
 
         // Lds memory usage in bytes

--- a/test/gemm/test/common_test_params.hpp
+++ b/test/gemm/test/common_test_params.hpp
@@ -126,8 +126,7 @@ namespace rocwmma
             //std::tuple<typename CooperativeGemm::BlockLevel::LdsRF>,
             std::tuple<typename CooperativeGemm::WaveLevel::LdsNT>,
             std::tuple<typename CooperativeGemm::BlockLevel::LdsRF>,
-#endif // ROCWMMA_EXTENDED_TESTS \
-    // Benchmark only wave-level as they are more performant
+#endif // ROCWMMA_EXTENDED_TESTS
             std::tuple<typename CooperativeGemm::WaveLevel::LdsTN>>;
 
         using TestGemmConfigsWgLevel = std::tuple<

--- a/test/gemm/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
@@ -46,12 +46,8 @@ namespace rocwmma
         using Layouts     = typename Base::TestLayoutsTN;
         using LayoutsLds  = typename Base::TestLdsLayoutTypes;
         using MappingsLds = typename Base::TestMappingsLds;
+        using BlocksXY    = std::tuple<std::tuple<I<4>, I<4>>>;
 
-#if __gfx908__
-        using BlocksXY = std::tuple<std::tuple<I<4>, I<4>>>;
-#else
-        using BlocksXY = std::tuple<std::tuple<I<4>, I<2>>>;
-#endif
         using KernelParams =
             typename CombineLists<Types, BlockSizes, Layouts, LayoutsLds, MappingsLds, BlocksXY>::
                 Result;
@@ -73,6 +69,10 @@ namespace rocwmma
 
 } // namespace rocwmma
 
+#ifndef __gfx90a__
+// TODO: Cannot build gfx90a version of this code due to compiler errors.
+// MUST SKIP this test at runtime for gfx90a
+
 // Test suite for unique parameterization
 class MmaSyncMultiLdsTest32x32TN4x4 : public rocwmma::GemmTest
 {
@@ -91,3 +91,5 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
                        ::testing::ValuesIn(rocwmma::TestParams::alphas()),
                        ::testing::ValuesIn(rocwmma::TestParams::betas())));
+
+#endif // !__gfx90a__

--- a/test/gemm/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_32x32_tn_4x4.cpp
@@ -61,17 +61,23 @@ namespace rocwmma
         static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
                       "Kernels from this generator do not match testing interface");
 
-        static inline typename KernelGenerator::ResultT kernels()
-        {
-            return KernelGenerator::generate();
-        }
+        static inline typename KernelGenerator::ResultT kernels();
     };
 
 } // namespace rocwmma
 
-#ifndef __gfx90a__
-// TODO: Cannot build gfx90a version of this code due to compiler errors.
-// MUST SKIP this test at runtime for gfx90a
+#if __gfx908__
+
+// TODO: Cannot build gfx90a version of this test due to compiler errors.
+// Build only for gfx908, but MUST skip runtime tests of this size for gfx90a
+
+namespace rocwmma
+{
+    inline typename TestParams::KernelGenerator::ResultT TestParams::kernels()
+    {
+        return KernelGenerator::generate();
+    }
+}
 
 // Test suite for unique parameterization
 class MmaSyncMultiLdsTest32x32TN4x4 : public rocwmma::GemmTest


### PR DESCRIPTION
- Some fp64 tests are failing at maximum register / LDS usage.
- Add some quirk checks to avoid corner case failures.