### PR TITLE
Fix bf16 performance metric on mi200

### DIFF
--- a/test/performance.hpp
+++ b/test/performance.hpp
@@ -100,7 +100,7 @@ namespace rocwmma
     {
         enum : uint32_t
         {
-            Multiplier = 512
+            Multiplier = 1024
         };
     };
 


### PR DESCRIPTION
Incorrect multiplier for MI-200 mfma bf16_1k instructions causes > 100% efficiency reporting