### PR TITLE
Add dgemv support to gemv code

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -62,5 +62,5 @@ endfunction()
 
 # Create sample targets
 add_rocwmma_sample(simple_gemm ${CMAKE_CURRENT_SOURCE_DIR}/simple_gemm.cpp)
-add_rocwmma_sample(sgemmv ${CMAKE_CURRENT_SOURCE_DIR}/sgemmv.cpp)
+add_rocwmma_sample(gemv ${CMAKE_CURRENT_SOURCE_DIR}/gemv.cpp)
 add_rocwmma_sample(simple_dlrm ${CMAKE_CURRENT_SOURCE_DIR}/simple_dlrm.cpp)

--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -44,6 +44,21 @@
     }
 #endif
 
+bool checkCurrentDeviceIsgfx908()
+{
+    int deviceId = 0;
+    CHECK_HIP_ERROR(hipGetDevice(&deviceId));
+    hipDeviceProp_t prop;
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&prop, deviceId));
+    std::string deviceName(prop.gcnArchName);
+    bool is_gfx908 = false;
+    if(deviceName.find("gfx908") != std::string::npos)
+    {
+        is_gfx908 = true;
+    }
+    return is_gfx908;
+}
+
 template <uint x>
 struct Log2
 {

--- a/samples/gemv.cpp
+++ b/samples/gemv.cpp
@@ -343,10 +343,10 @@ __host__ void gemv_test(uint32_t m, uint32_t n, uint32_t k, float alpha, float b
 
 int main()
 {
-    const uint32_t m = 16;
-    const uint32_t k = 16;
+    const uint32_t m = 256;
+    const uint32_t k = 256;
     const uint32_t n = T_BLOCK_Y * ROCWMMA_N;
-    std::cout << "*******Running rocwmma_sgemv sample*******" << std::endl;
+    std::cout << "*******Running SGEMV sample*******" << std::endl;
     gemv_test<float16_t, float32_t>(m, n, k, 2.1f, 2.1f);
 
     bool is_gfx908 = checkCurrentDeviceIsgfx908();
@@ -355,7 +355,7 @@ int main()
     #if !__gfx908__
     if(!is_gfx908)
     {
-        std::cout << std::endl << "*******Running rocwmma_dgemv sample*******" << std::endl; 
+        std::cout << std::endl << "*******Running DGEMV sample*******" << std::endl; 
         gemv_test<float64_t, float64_t>(m, n, k, 2.1f, 2.1f);
     }
     #endif


### PR DESCRIPTION
This PR adds:
1. DGEMV sample to the existing gemv code and it was tested on gfx90a.
2. Renamed sgemmv to gemv, as the sample code now supports more than one precision.