### PR TITLE
Fix branching errors

### DIFF
--- a/library/include/rocwmma/rocwmma.hpp
+++ b/library/include/rocwmma/rocwmma.hpp
@@ -369,11 +369,14 @@ namespace rocwmma
               typename InputT,
               typename ComputeT,
               typename LayoutA,
-              typename LayoutB>
-    __device__ void mma_sync(fragment<accumulator, BlockM, BlockN, BlockK, ComputeT>&           d,
-                             fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA> const& a,
-                             fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB> const& b,
-                             fragment<accumulator, BlockM, BlockN, BlockK, ComputeT> const&     c);
+              typename LayoutB,
+              typename LayoutC,
+              typename LayoutD>
+    __device__ void
+        mma_sync(fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutD>&       d,
+                 fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA> const&      a,
+                 fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB> const&      b,
+                 fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutC> const& c);
 
     //! Synchronization point for all wavefronts in a workgroup.
     __device__ void synchronize_workgroup();

--- a/library/include/rocwmma/rocwmma_impl.hpp
+++ b/library/include/rocwmma/rocwmma_impl.hpp
@@ -295,11 +295,14 @@ namespace rocwmma
               typename InputT,
               typename ComputeT,
               typename LayoutA,
-              typename LayoutB>
-    __device__ void mma_sync(fragment<accumulator, BlockM, BlockN, BlockK, ComputeT>&           d,
-                             fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA> const& a,
-                             fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB> const& b,
-                             fragment<accumulator, BlockM, BlockN, BlockK, ComputeT> const&     c)
+              typename LayoutB,
+              typename LayoutC,
+              typename LayoutD>
+    __device__ void
+        mma_sync(fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutD>&       d,
+                 fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA> const&      a,
+                 fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB> const&      b,
+                 fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutC> const& c)
     {
         using MFMA  = Mfma<InputT, ComputeT, BlockM, BlockN, BlockK>;
         using FragA = typename std::decay<decltype(a)>::type;

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
@@ -40,6 +40,18 @@
 
 namespace rocwmma
 {
+    ///
+    /// This class of kernel is an extension of the naive kernel whereas
+    /// each wave is responsible for calculating a macro tile area of
+    /// BlocksX * BlockM x BlocksY * BlockN
+    ///
+    /// Kernel behaviour is described by:
+    /// PGR0 = Prefetch Global Read = 0, no prefetch
+    /// LB0 = Lds Blocks = 0, no Lds usage
+    /// MP0 = Mfma Priority = 0, no setprio
+    /// MB = Multi-block, BlocksX * BlocksY > 1
+    /// NC = Non-cooperative
+    ///
     template <uint32_t BlockM,
               uint32_t BlockN,
               uint32_t BlockK,
@@ -83,151 +95,140 @@ namespace rocwmma
         std::get<0>(matrixCoordC) *= BlocksX;
         std::get<1>(matrixCoordC) *= BlocksY;
 
-        if((std::get<0>(matrixCoordC) + BlocksX * BlockM) <= m
-           && (std::get<1>(matrixCoordC) + BlocksY * BlockN) <= n && (BlockK < k))
+        if(std::get<0>(matrixCoordC) + BlocksX * BlockM > m
+           || std::get<1>(matrixCoordC) + BlocksY * BlockN > n)
         {
-            // Targets for C sub-matrices
-            CoordT  subMatrixCoordsC[BlocksX][BlocksY];
-            FragAcc fragsAccum[BlocksX][BlocksY];
+            return;
+        }
 
-            /// Initialization
+        if(BlockK > k)
+        {
+            return;
+        }
+
+        // Targets for C sub-matrices
+        CoordT  subMatrixCoordsC[BlocksX][BlocksY];
+        FragAcc fragsAccum[BlocksX][BlocksY];
+
+        /// Initialization
 #pragma unroll
+        for(int i = 0; i < BlocksX; i++)
+        {
+#pragma unroll
+            for(int j = 0; j < BlocksY; j++)
+            {
+                // Initialize sub matrix coordinates
+                std::get<0>(subMatrixCoordsC[i][j]) += std::get<0>(matrixCoordC) + i * BlockM;
+                std::get<1>(subMatrixCoordsC[i][j]) += std::get<1>(matrixCoordC) + j * BlockN;
+
+                // Initialize accumulators
+                fill_fragment(fragsAccum[i][j], static_cast<ComputeT>(0));
+            }
+        }
+
+        /// Setup global read addresses
+        InputT const* globalAddrsA[BlocksX];
+        InputT const* globalAddrsB[BlocksY];
+
+        // Blocks in the same row share the same starting address for A
+#pragma unroll
+        for(int i = 0; i < BlocksX; i++)
+        {
+            globalAddrsA[i] = MappingA::dataCoord(
+                a, std::make_pair(std::get<0>(subMatrixCoordsC[i][0]), 0), lda);
+        }
+
+        // Blocks in the same col share the same starting address for B
+#pragma unroll
+        for(int i = 0; i < BlocksY; i++)
+        {
+            globalAddrsB[i] = MappingB::dataCoord(
+                b, std::make_pair(0, std::get<1>(subMatrixCoordsC[0][i])), ldb);
+        }
+
+        /// Setup address increments.
+        // A steps BlockK through m x k
+        // B steps BlockK through k x n
+        auto incrA  = MappingA::dataOffset(std::make_pair(0, BlockK), lda);
+        auto incrB  = MappingB::dataOffset(std::make_pair(BlockK, 0), ldb);
+        auto stepsK = k / BlockK;
+
+        /// Accumulate A * B
+        for(int currentStep = 0; currentStep < stepsK; currentStep++)
+        {
+            // Cache the B-Blocks for re-use
+            FragB cachedFragsB[BlocksY];
+            FragA fragA;
+
+            // Synchronize workgroup increases chances for cache hits
+            synchronize_workgroup();
+
+#pragma unroll
+            for(int j = 0; j < BlocksY; j++)
+            {
+                load_matrix_sync(cachedFragsB[j], globalAddrsB[j], ldb);
+                globalAddrsB[j] += incrB;
+            }
+
+            //#pragma unroll
             for(int i = 0; i < BlocksX; i++)
             {
-#pragma unroll
+                // A fragment will be re-used for each B
+                load_matrix_sync(fragA, globalAddrsA[i], lda);
+                globalAddrsA[i] += incrA;
+
+                //#pragma unroll
                 for(int j = 0; j < BlocksY; j++)
                 {
-                    // Initialize sub matrix coordinates
-                    std::get<0>(subMatrixCoordsC[i][j]) += std::get<0>(matrixCoordC) + i * BlockM;
-                    std::get<1>(subMatrixCoordsC[i][j]) += std::get<1>(matrixCoordC) + j * BlockN;
-
-                    // Initialize accumulators
-                    fill_fragment(fragsAccum[i][j], static_cast<ComputeT>(0));
+                    mma_sync(fragsAccum[i][j], fragA, cachedFragsB[j], fragsAccum[i][j]);
                 }
             }
+        }
 
-            /// Accumulate A * B
-            if(alpha)
+        // Initialize C frags
+        FragC fragsC[BlocksX][BlocksY];
+
+#pragma unroll
+        for(int i = 0; i < BlocksX; i++)
+        {
+#pragma unroll
+            for(int j = 0; j < BlocksY; j++)
             {
-                // Setup global read addresses
-                InputT const* globalAddrsA[BlocksX];
-                InputT const* globalAddrsB[BlocksY];
-
-                // Blocks in the same row share the same starting address for A
-#pragma unroll
-                for(int i = 0; i < BlocksX; i++)
-                {
-                    globalAddrsA[i] = MappingA::dataCoord(
-                        a, std::make_pair(std::get<0>(subMatrixCoordsC[i][0]), 0), lda);
-                }
-
-                // Blocks in the same col share the same starting address for B
-#pragma unroll
-                for(int i = 0; i < BlocksY; i++)
-                {
-                    globalAddrsB[i] = MappingB::dataCoord(
-                        b, std::make_pair(0, std::get<1>(subMatrixCoordsC[0][i])), ldb);
-                }
-
-                // Setup address increments.
-                // A steps BlockK through m x k
-                // B steps BlockK through k x n
-                auto incrA  = MappingA::dataOffset(std::make_pair(0, BlockK), lda);
-                auto incrB  = MappingB::dataOffset(std::make_pair(BlockK, 0), ldb);
-                auto stepsK = k / BlockK;
-
-                for(int currentStep = 0; currentStep < stepsK; currentStep++)
-                {
-                    // Cache the B-Blocks for re-use
-                    FragB cachedFragsB[BlocksY];
-                    FragA fragA;
-
-                    // Synchronize workgroup increases chances for cache hits
-                    synchronize_workgroup();
-
-#pragma unroll
-                    for(int j = 0; j < BlocksY; j++)
-                    {
-                        load_matrix_sync(cachedFragsB[j], globalAddrsB[j], ldb);
-                        globalAddrsB[j] += incrB;
-                    }
-
-                    //#pragma unroll
-                    for(int i = 0; i < BlocksX; i++)
-                    {
-                        // A fragment will be re-used for each B
-                        load_matrix_sync(fragA, globalAddrsA[i], lda);
-                        globalAddrsA[i] += incrA;
-
-                        //#pragma unroll
-                        for(int j = 0; j < BlocksY; j++)
-                        {
-                            mma_sync(fragsAccum[i][j], fragA, cachedFragsB[j], fragsAccum[i][j]);
-                        }
-                    }
-                }
+                auto* addrC = MappingC::dataCoord(c, subMatrixCoordsC[i][j], ldc);
+                load_matrix_sync(fragsC[i][j],
+                                 addrC,
+                                 ldc,
+                                 std::is_same<LayoutC, row_major>::value ? mem_row_major
+                                                                         : mem_col_major);
             }
+        }
 
-            // Initialize C frags
-            FragC fragsC[BlocksX][BlocksY];
-
-            if(beta)
+        // D = alpha * accumAB + beta * C
+#pragma unroll
+        for(int i = 0; i < BlocksX; i++)
+        {
+#pragma unroll
+            for(int j = 0; j < BlocksY; j++)
             {
+                auto& fragAcc = fragsAccum[i][j];
+                auto& fragC   = fragsC[i][j];
+
 #pragma unroll
-                for(int i = 0; i < BlocksX; i++)
+                for(int e = 0; e < fragC.num_elements; ++e)
                 {
-#pragma unroll
-                    for(int j = 0; j < BlocksY; j++)
-                    {
-                        auto* addrC = MappingC::dataCoord(c, subMatrixCoordsC[i][j], ldc);
-                        load_matrix_sync(fragsC[i][j],
-                                         addrC,
-                                         ldc,
-                                         std::is_same<LayoutC, row_major>::value ? mem_row_major
-                                                                                 : mem_col_major);
-                    }
+                    fragC.x[e]
+                        = OutputT(alpha * ComputeT(fragAcc.x[e]) + beta * ComputeT(fragC.x[e]));
                 }
-            }
-            else
-            {
-#pragma unroll
-                for(int i = 0; i < BlocksX; i++)
-                {
-#pragma unroll
-                    for(int j = 0; j < BlocksY; j++)
-                    {
-                        fill_fragment(fragsC[i][j], static_cast<OutputT>(0));
-                    }
-                }
-            }
 
-// D = alpha * accumAB + beta * C
-#pragma unroll
-            for(int i = 0; i < BlocksX; i++)
-            {
-#pragma unroll
-                for(int j = 0; j < BlocksY; j++)
-                {
-                    auto& fragAcc = fragsAccum[i][j];
-                    auto& fragC   = fragsC[i][j];
+                // Output addresss
+                auto* addrD = MappingD::dataCoord(d, subMatrixCoordsC[i][j], ldd);
 
-#pragma unroll
-                    for(int i = 0; i < fragC.num_elements; ++i)
-                    {
-                        fragC.x[i]
-                            = OutputT(alpha * ComputeT(fragAcc.x[i]) + beta * ComputeT(fragC.x[i]));
-                    }
-
-                    // Output addresss
-                    auto* addrD = MappingD::dataCoord(d, subMatrixCoordsC[i][j], ldd);
-
-                    // Store the output
-                    store_matrix_sync(addrD,
-                                      fragC,
-                                      ldd,
-                                      std::is_same<LayoutD, row_major>::value ? mem_row_major
-                                                                              : mem_col_major);
-                }
+                // Store the output
+                store_matrix_sync(addrD,
+                                  fragC,
+                                  ldd,
+                                  std::is_same<LayoutD, row_major>::value ? mem_row_major
+                                                                          : mem_col_major);
             }
         }
     }

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
@@ -87,8 +87,8 @@ namespace rocwmma
 
         using FragA   = fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA>;
         using FragB   = fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB>;
-        using FragC   = fragment<accumulator, BlockM, BlockN, BlockK, OutputT>;
-        using FragAcc = fragment<accumulator, BlockM, BlockN, BlockK, ComputeT>;
+        using FragC   = fragment<accumulator, BlockM, BlockN, BlockK, OutputT, LayoutC>;
+        using FragAcc = fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutD>;
 
         // Target starting C / D block on 2D grid, offset by blocks per wave
         auto matrixCoordC = MappingC::matrixCoord();
@@ -195,11 +195,7 @@ namespace rocwmma
             for(int j = 0; j < BlocksY; j++)
             {
                 auto* addrC = MappingC::dataCoord(c, subMatrixCoordsC[i][j], ldc);
-                load_matrix_sync(fragsC[i][j],
-                                 addrC,
-                                 ldc,
-                                 std::is_same<LayoutC, row_major>::value ? mem_row_major
-                                                                         : mem_col_major);
+                load_matrix_sync(fragsC[i][j], addrC, ldc);
             }
         }
 
@@ -224,11 +220,7 @@ namespace rocwmma
                 auto* addrD = MappingD::dataCoord(d, subMatrixCoordsC[i][j], ldd);
 
                 // Store the output
-                store_matrix_sync(addrD,
-                                  fragC,
-                                  ldd,
-                                  std::is_same<LayoutD, row_major>::value ? mem_row_major
-                                                                          : mem_col_major);
+                store_matrix_sync(addrD, fragC, ldd);
             }
         }
     }

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
@@ -79,8 +79,8 @@ namespace rocwmma
     {
         using FragA   = fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA>;
         using FragB   = fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB>;
-        using FragC   = fragment<accumulator, BlockM, BlockN, BlockK, OutputT>;
-        using FragAcc = fragment<accumulator, BlockM, BlockN, BlockK, ComputeT>;
+        using FragC   = fragment<accumulator, BlockM, BlockN, BlockK, OutputT, LayoutC>;
+        using FragAcc = fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutD>;
 
         using MappingA = MappingUtil<BlockM, BlockK, InputT, LayoutA>;
         using MappingB = MappingUtil<BlockK, BlockN, InputT, LayoutB>;
@@ -141,10 +141,7 @@ namespace rocwmma
 
         // Setup address and load C
         auto* addrC = MappingC::dataCoord(c, matrixCoordC, ldc);
-        load_matrix_sync(fragC,
-                         addrC,
-                         ldc,
-                         std::is_same<LayoutC, row_major>::value ? mem_row_major : mem_col_major);
+        load_matrix_sync(fragC, addrC, ldc);
 
         // D = alpha * accumAB + beta * C
 #pragma unroll
@@ -157,10 +154,7 @@ namespace rocwmma
         auto* addrD = MappingD::dataCoord(d, matrixCoordC, ldd);
 
         // Store the output
-        store_matrix_sync(addrD,
-                          fragC,
-                          ldd,
-                          std::is_same<LayoutD, row_major>::value ? mem_row_major : mem_col_major);
+        store_matrix_sync(addrD, fragC, ldd);
     }
 
 } // namespace rocwmma

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
@@ -40,6 +40,18 @@
 
 namespace rocwmma
 {
+    ///
+    /// This class of kernel is a naive kernel whereas
+    /// each wave is responsible for calculating a macro tile area of
+    /// a single block: BlockM x BlockN
+    ///
+    /// Kernel behaviour is described by:
+    /// PGR0 = Prefetch Global Read = 0, no prefetch
+    /// LB0 = Lds Blocks = 0, no Lds usage
+    /// MP0 = Mfma Priority = 0, no setprio
+    /// SB = Single-block
+    /// NC = Non-cooperative
+    ///
 
     template <uint32_t BlockM,
               uint32_t BlockN,
@@ -78,79 +90,77 @@ namespace rocwmma
         // Target C / D block on 2D grid
         auto matrixCoordC = MappingC::matrixCoord();
 
-        if(std::get<0>(matrixCoordC) < m && std::get<1>(matrixCoordC) < n)
+        if(std::get<0>(matrixCoordC) + BlockM > m || std::get<1>(matrixCoordC) + BlockN > n)
         {
-            // Initialize accumulator
-            auto fragAcc = FragAcc();
-            fill_fragment(fragAcc, static_cast<ComputeT>(0));
-
-            // Accumulate A * B
-            if(alpha)
-            {
-                // Setup starting addresses
-                // Offset A to col 0
-                // Offset B to row 0
-                auto* addrA = MappingA::dataCoord(a, MappingC::matrixCoordN(0), lda);
-                auto* addrB = MappingB::dataCoord(b, MappingC::matrixCoordM(0), ldb);
-
-                // Setup address increments.
-                // A steps BlockK through m x k
-                // B steps BlockK through k x n
-                auto incrA = MappingA::dataOffset(std::make_pair(0, BlockK), lda);
-                auto incrB = MappingB::dataOffset(std::make_pair(BlockK, 0), ldb);
-
-                auto count = k / BlockK;
-                for(int i = 0; i < count; i++)
-                {
-                    // Keeping the workgroup in sync here is not necessary for correctness.
-                    // HOWEVER, if we keep waves in sync chances are good we may
-                    // benefit from cache hits on re-used data from A and B global loads.
-                    synchronize_workgroup();
-
-                    auto fragA = FragA();
-                    auto fragB = FragB();
-
-                    // Load and multiply
-                    load_matrix_sync(fragA, addrA, lda);
-                    load_matrix_sync(fragB, addrB, ldb);
-                    mma_sync(fragAcc, fragA, fragB, fragAcc);
-
-                    addrA += incrA;
-                    addrB += incrB;
-                }
-            }
-
-            // Load C
-            auto fragC = FragC();
-            fill_fragment(fragC, static_cast<OutputT>(0));
-            if(beta)
-            {
-                // Setup address
-                auto* addrC = MappingC::dataCoord(c, matrixCoordC, ldc);
-                load_matrix_sync(fragC,
-                                 addrC,
-                                 ldc,
-                                 std::is_same<LayoutC, row_major>::value ? mem_row_major
-                                                                         : mem_col_major);
-            }
-
-            // D = alpha * accumAB + beta * C
-#pragma unroll
-            for(int i = 0; i < fragC.num_elements; ++i)
-            {
-                fragC.x[i] = OutputT(alpha * ComputeT(fragAcc.x[i]) + beta * ComputeT(fragC.x[i]));
-            }
-
-            // Output addresss
-            auto* addrD = MappingD::dataCoord(d, matrixCoordC, ldd);
-
-            // Store the output
-            store_matrix_sync(addrD,
-                              fragC,
-                              ldd,
-                              std::is_same<LayoutD, row_major>::value ? mem_row_major
-                                                                      : mem_col_major);
+            return;
         }
+
+        if(BlockK > k)
+        {
+            return;
+        }
+
+        // Initialize accumulator
+        auto fragAcc = FragAcc();
+        fill_fragment(fragAcc, static_cast<ComputeT>(0));
+
+        // Setup starting addresses
+        // Offset A to col 0
+        // Offset B to row 0
+        auto* addrA = MappingA::dataCoord(a, MappingC::matrixCoordN(0), lda);
+        auto* addrB = MappingB::dataCoord(b, MappingC::matrixCoordM(0), ldb);
+
+        // Setup address increments.
+        // A steps BlockK through m x k
+        // B steps BlockK through k x n
+        auto incrA = MappingA::dataOffset(std::make_pair(0, BlockK), lda);
+        auto incrB = MappingB::dataOffset(std::make_pair(BlockK, 0), ldb);
+        auto count = k / BlockK;
+
+        // Accumulate A * B
+        for(int i = 0; i < count; i++)
+        {
+            // Keeping the workgroup in sync here is not necessary for correctness.
+            // HOWEVER, if we keep waves in sync chances are good we may
+            // benefit from cache hits on re-used data from A and B global loads.
+            synchronize_workgroup();
+
+            auto fragA = FragA();
+            auto fragB = FragB();
+
+            // Load and multiply
+            load_matrix_sync(fragA, addrA, lda);
+            load_matrix_sync(fragB, addrB, ldb);
+            mma_sync(fragAcc, fragA, fragB, fragAcc);
+
+            addrA += incrA;
+            addrB += incrB;
+        }
+
+        auto fragC = FragC();
+
+        // Setup address and load C
+        auto* addrC = MappingC::dataCoord(c, matrixCoordC, ldc);
+        load_matrix_sync(fragC,
+                         addrC,
+                         ldc,
+                         std::is_same<LayoutC, row_major>::value ? mem_row_major : mem_col_major);
+
+        // D = alpha * accumAB + beta * C
+#pragma unroll
+        for(int i = 0; i < fragC.num_elements; ++i)
+        {
+            fragC.x[i] = OutputT(alpha * ComputeT(fragAcc.x[i]) + beta * ComputeT(fragC.x[i]));
+        }
+
+        // Output addresss
+        auto* addrD = MappingD::dataCoord(d, matrixCoordC, ldd);
+
+        // Store the output
+        store_matrix_sync(addrD,
+                          fragC,
+                          ldd,
+                          std::is_same<LayoutD, row_major>::value ? mem_row_major : mem_col_major);
     }
 
 } // namespace rocwmma

--- a/test/gemm/gemm_common_test_params.hpp
+++ b/test/gemm/gemm_common_test_params.hpp
@@ -242,13 +242,22 @@ namespace rocwmma
         /// Per-wave output block coverage
         ///
         using TestBlocks1x1 = std::tuple<std::tuple<I<1>, I<1>>>;
-        using TestBlocks2x1 = std::tuple<std::tuple<I<2>, I<1>>>;
         using TestBlocks1x2 = std::tuple<std::tuple<I<1>, I<2>>>;
+        using TestBlocks1x4 = std::tuple<std::tuple<I<1>, I<4>>>;
+        using TestBlocks1x8 = std::tuple<std::tuple<I<1>, I<8>>>;
+
+        using TestBlocks2x1 = std::tuple<std::tuple<I<2>, I<1>>>;
         using TestBlocks2x2 = std::tuple<std::tuple<I<2>, I<2>>>;
         using TestBlocks2x4 = std::tuple<std::tuple<I<2>, I<4>>>;
+        using TestBlocks2x8 = std::tuple<std::tuple<I<2>, I<8>>>;
+
+        using TestBlocks4x1 = std::tuple<std::tuple<I<4>, I<1>>>;
         using TestBlocks4x2 = std::tuple<std::tuple<I<4>, I<2>>>;
         using TestBlocks4x4 = std::tuple<std::tuple<I<4>, I<4>>>;
         using TestBlocks4x8 = std::tuple<std::tuple<I<4>, I<8>>>;
+
+        using TestBlocks8x1 = std::tuple<std::tuple<I<8>, I<1>>>;
+        using TestBlocks8x2 = std::tuple<std::tuple<I<8>, I<2>>>;
         using TestBlocks8x4 = std::tuple<std::tuple<I<8>, I<4>>>;
         using TestBlocks8x8 = std::tuple<std::tuple<I<8>, I<8>>>;
 
@@ -313,12 +322,12 @@ namespace rocwmma
 
         static inline std::vector<AlphaT> alphas()
         {
-            return {2.0};
+            return {static_cast<AlphaT>(2)};
         }
 
         static inline std::vector<BetaT> betas()
         {
-            return {2.0};
+            return {static_cast<BetaT>(2)};
         }
     };
 

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -300,16 +300,16 @@ namespace rocwmma
                         LayoutC,
                         LayoutD>::reset()
     {
-        mTBlockX = mTBlockY = 0;
-        mM = mN = mK = 0;
-        mLda = mLdb = mLdc = mLdd = 0;
-        mAlpha = mBeta = ComputeT(0.0f);
+        mTBlockX = mTBlockY = 0u;
+        mM = mN = mK = 0u;
+        mLda = mLdb = mLdc = mLdd = 0u;
+        mAlpha = mBeta = static_cast<ComputeT>(0u);
 
         mRepeats =
 #ifdef ROCWMMA_VALIDATION_TESTS
-            1;
+            1u;
 #else
-            5;
+            5u;
 #endif
         mRunFlag          = true;
         mValidationResult = false;
@@ -622,7 +622,7 @@ namespace rocwmma
             using HandleGuardT = std::unique_ptr<rocblas_handle, void (*)(rocblas_handle*)>;
             auto handleGuard   = HandleGuardT(&handle, [](rocblas_handle* handle) {
                 CHECK_ROCBLAS_ERROR(rocblas_destroy_handle(*handle));
-              });
+            });
 
             auto rocBlasKernel = [this, &handle]() {
                 auto& dataInstance = DataStorage::instance();


### PR DESCRIPTION
- Depends on PR 56
- Large macro tile Gemm_PGR0_LB0_MP0_MB_NC kernels failed validation
- Compiler investigation showed branching complexity on mixed uniform / non-uniform conditions may elicit incorrect code pathing.
- rocWMMA workaround is to simplify boundary condition checks, as well as remove non-zero alpha / beta checks.
- Alpha / beta = 0 checks affect very small number of uncommon cases offering small optimizations.
- Writing out to D can use supplied LayoutD instead of ternary op as runtime function parameter.