### PR TITLE
Adjust starting MaxVW test to dwordx4 width

### DIFF
--- a/library/include/rocwmma/internal/constants.hpp
+++ b/library/include/rocwmma/internal/constants.hpp
@@ -29,14 +29,14 @@
 namespace rocwmma
 {
 
-    static constexpr uint32_t AMDGCN_WAVE_SIZE                   = 64;
-    static constexpr uint32_t AMDGCN_REGISTER_ELEMENT_SIZE_BYTES = 4;
+    static constexpr uint32_t AMDGCN_WAVE_SIZE                   = 64u;
+    static constexpr uint32_t AMDGCN_REGISTER_ELEMENT_SIZE_BYTES = 4u;
     static constexpr uint32_t AMDGCN_REGISTER_SIZE_BYTES
         = AMDGCN_REGISTER_ELEMENT_SIZE_BYTES * AMDGCN_WAVE_SIZE;
 
-    static constexpr uint32_t AMDGCN_LDS_MAX_SIZE_BYTES    = 65536;
-    static constexpr uint32_t AMDGCN_CACHE_LINE_SIZE_BYTES = 64;
-    static constexpr uint32_t AMDGCN_DWORD_SIZE_BYTES = 4;
+    static constexpr uint32_t AMDGCN_LDS_MAX_SIZE_BYTES    = 65536u;
+    static constexpr uint32_t AMDGCN_CACHE_LINE_SIZE_BYTES = 64u;
+    static constexpr uint32_t AMDGCN_DWORD_SIZE_BYTES      = 4u;
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/io_traits.hpp
+++ b/library/include/rocwmma/internal/io_traits.hpp
@@ -166,7 +166,7 @@ namespace rocwmma
         template <uint32_t BlockDim,
                   uint32_t BlockK,
                   typename DataT,
-                  uint32_t TestWidth = AMDGCN_DWORD_SIZE_BYTES * 8 / sizeof(DataT)>
+                  uint32_t TestWidth = AMDGCN_DWORD_SIZE_BYTES * 4 / sizeof(DataT)>
         struct VecWidthTraits
         {
             enum : uint32_t

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_device_func.hpp
@@ -198,7 +198,7 @@ namespace rocwmma
         ///
         /// Accumulate A * B
         ///
-        for(int currentK = BlockK; currentK < k; currentK += BlockK)
+        for(auto currentK = BlockK; currentK < k; currentK += BlockK)
         {
             typename GlobalMapping::MfmaBuffA fragsA;
             typename GlobalMapping::MfmaBuffB fragsB;

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -27,8 +27,8 @@
 #ifndef ROCWMMA_KERNEL_BASE_IMPL_HPP
 #define ROCWMMA_KERNEL_BASE_IMPL_HPP
 
-#include <tuple>
 #include <cmath>
+#include <tuple>
 
 #include <hip/hip_ext.h>
 #include <hip/hip_runtime_api.h>
@@ -623,7 +623,7 @@ namespace rocwmma
             using HandleGuardT = std::unique_ptr<rocblas_handle, void (*)(rocblas_handle*)>;
             auto handleGuard   = HandleGuardT(&handle, [](rocblas_handle* handle) {
                 CHECK_ROCBLAS_ERROR(rocblas_destroy_handle(*handle));
-            });
+              });
 
             auto rocBlasKernel = [this, &handle]() {
                 auto& dataInstance = DataStorage::instance();
@@ -736,7 +736,8 @@ namespace rocwmma
                     auto elapsedTimeMs        = float64_t(timeMs);
                     auto measuredTFlopsPerSec = calculateTFlopsPerSec(mM, mN, mK, elapsedTimeMs)
                                                 * static_cast<float64_t>(mRepeats);
-                    mReferenceEfficiency = round(measuredTFlopsPerSec / devicePeakGFlopsPerSec * 100000.0);
+                    mReferenceEfficiency
+                        = round(measuredTFlopsPerSec / devicePeakGFlopsPerSec * 100000.0);
                 }
 
                 CHECK_HIP_ERROR(hipEventDestroy(startEvent));
@@ -804,8 +805,11 @@ namespace rocwmma
                 = compareEqualLaunchKernel<OutputT, OutputT, DeviceLayoutD, LayoutD>(
                     dataInstance->deviceD().get(), reference.get(), mM, mN, errorTolerance);
 
-            // MatrixUtil<DeviceLayoutD>::print(result0.get(), mM, mN);
-            // MatrixUtil<LayoutD>::print(result1.get(), mM, mN);
+            // auto result = dataInstance->template allocHost<OutputT>(sizeD);
+            // dataInstance->copyData(result, dataInstance->deviceD(), sizeD);
+
+            // MatrixUtil<DeviceLayoutD>::print(dataInstance->hostD().get(), mM, mN);
+            // MatrixUtil<LayoutD>::print(result.get(), mM, mN);
 
             EXPECT_TRUE(mValidationResult) << "Max relative error: " << mMaxRelativeError;
         }


### PR DESCRIPTION
- Compiler can generate maximum dwordx4 load / store instructions. We can use this as the cap on MaxVW setting.
- In situations where MaxVW is actually used, collaborative loads and stores might distribute the load better with smaller fragment splits.
- UPDATE: Performance improvements in fp16, bf16 observed in ad hoc tests.
- f16_f16_f32 pushing past 80TFlops