### PR TITLE
Gemm manual template instantiate

### DIFF
--- a/test/gemm/CMakeLists.txt
+++ b/test/gemm/CMakeLists.txt
@@ -29,8 +29,8 @@ include( CMakeDependentOption )
 cmake_dependent_option( ROCWMMA_VALIDATE_WITH_ROCBLAS "Use rocBLAS for validation" ON "ROCWMMA_BUILD_VALIDATION_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_BENCHMARK_WITH_ROCBLAS "Include rocBLAS benchmark performance comparisons" OFF "ROCWMMA_BUILD_BENCHMARK_TESTS" OFF )
 
-#set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
-#set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
 
 if(ROCWMMA_VALIDATE_WITH_ROCBLAS OR ROCWMMA_BENCHMARK_WITH_ROCBLAS)
   find_package( rocblas REQUIRED PATHS /opt/rocm /opt/rocm/rocblas $ENV{ROCBLAS_DIR} )
@@ -94,7 +94,8 @@ endfunction()
 
 # GEMM common test sources
 set(GemmCommonSources ${ROCWMMA_COMMON_TEST_SOURCES}
-                      ${CMAKE_CURRENT_SOURCE_DIR}/gemm_kernel_base.cpp)
+                      ${CMAKE_CURRENT_SOURCE_DIR}/gemm_kernel_base.cpp
+                      ${CMAKE_CURRENT_SOURCE_DIR}/gemm_resource.cpp)
 
 # Tests for cooperative kernel classes
 add_subdirectory(gemm_PGR1_LB2_MP0_MB_CP)

--- a/test/gemm/gemm_kernel_base.cpp
+++ b/test/gemm/gemm_kernel_base.cpp
@@ -24,9 +24,830 @@
  *
  *******************************************************************************/
 
-#include "gemm_kernel_base.hpp"
+#define ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(InputT, OutputT, ComputeT) \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   row_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   row_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<16u,                                 \
+                                   16u,                                 \
+                                   256u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   8u,                                  \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   16u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   32u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   64u,                                 \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;                          \
+    template struct GemmKernelBase<32u,                                 \
+                                   32u,                                 \
+                                   128u,                                \
+                                   InputT,                              \
+                                   OutputT,                             \
+                                   ComputeT,                            \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major,                           \
+                                   col_major>;
+
+#include "gemm_kernel_base_impl.hpp"
 
 namespace rocwmma
 {
     bool KernelI::sHeaderPrinted = false;
+
+    // All supported instantiations
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(int8_t, int32_t, int32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, float32_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float32_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, float32_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float32_t, float32_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float64_t, float64_t, float64_t);
+
+#if defined(ROCWMMA_EXTENDED_TESTS)
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(int8_t, int8_t, int32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, bfloat16_t, bfloat16_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, bfloat16_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float16_t, float16_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float16_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, hfloat16_t, hfloat16_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, hfloat16_t, float32_t);
+#endif // ROCWMMA_EXTENDED_TESTS
+
 } // namespace rocwmma

--- a/test/gemm/gemm_kernel_base.hpp
+++ b/test/gemm/gemm_kernel_base.hpp
@@ -159,11 +159,9 @@ namespace rocwmma
 
         // Performance
         float64_t mElapsedTimeMs, mTotalGFlops, mMeasuredTFlopsPerSec;
-        int32_t mEfficiency, mReferenceEfficiency;
+        int32_t   mEfficiency, mReferenceEfficiency;
     };
 
 } // namespace rocwmma
-
-#include "gemm_kernel_base_impl.hpp"
 
 #endif // ROCWMMA_KERNEL_BASE_HPP

--- a/test/gemm/gemm_resource.cpp
+++ b/test/gemm/gemm_resource.cpp
@@ -1,0 +1,20 @@
+#include "gemm_resource_impl.hpp"
+
+namespace rocwmma
+{
+    // All supported instantiations
+    template struct GemmResource<int8_t, int32_t>;
+    template struct GemmResource<bfloat16_t, float32_t>;
+    template struct GemmResource<float16_t, float32_t>;
+    template struct GemmResource<hfloat16_t, float32_t>;
+    template struct GemmResource<float32_t, float32_t>;
+    template struct GemmResource<float64_t, float64_t>;
+
+#if defined(ROCWMMA_EXTENDED_TESTS)
+    template struct GemmResource<int8_t, int8_t>;
+    template struct GemmResource<bfloat16_t, bfloat16_t>;
+    template struct GemmResource<float16_t, float16_t>;
+    template struct GemmResource<hfloat16_t, hfloat16_t>;
+#endif // ROCWMMA_EXTENDED_TESTS
+
+}

--- a/test/gemm/gemm_resource.hpp
+++ b/test/gemm/gemm_resource.hpp
@@ -87,7 +87,7 @@ namespace rocwmma
     private: // No public instantiation except make_unique.
              // No copy
         GemmResource();
-        GemmResource(const GemmResource&) = delete;
+        GemmResource(const GemmResource&)            = delete;
         GemmResource& operator=(const GemmResource&) = delete;
 
     public:
@@ -121,7 +121,5 @@ namespace rocwmma
     };
 
 } // namespace rocwmma
-
-#include "gemm_resource_impl.hpp"
 
 #endif // ROCWMMA_GEMM_RESOURCE_HPP


### PR DESCRIPTION
Depends on PR#61.

Disables automatic template instantiation for GemmResource and GemmKernelBase classes.

Instead, focuses manual instantiation of all expected variations into their own .cpp compilation units that are linked once.

This reduces extra unnecessary automatic instantiations in each testing compilation unit as they are used in more than one place. It helps to reduce compile times, especially with extended tests. and the thousands of kernels that use the same type.