### PR TITLE
Fix rocBLAS version to 5.2 release

### DIFF
--- a/test/gemm/CMakeLists.txt
+++ b/test/gemm/CMakeLists.txt
@@ -33,8 +33,8 @@ set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
 set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
 
 if(ROCWMMA_VALIDATE_WITH_ROCBLAS OR ROCWMMA_BENCHMARK_WITH_ROCBLAS)
-  find_package( rocblas REQUIRED PATHS /opt/rocm /opt/rocm/rocblas $ENV{ROCBLAS_DIR} )
-  rocm_package_add_dependencies("rocblas >= 2.32.0" COMPONENT tests)
+  find_package( rocblas 2.44.0 REQUIRED PATHS /opt/rocm /opt/rocm/rocblas $ENV{ROCBLAS_DIR} )
+  rocm_package_add_dependencies("rocblas >= 2.44.0" COMPONENT tests)
 endif()
 
 set(ROCWMMA_TEST_GEMM_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${ROCWMMA_TEST_GEMM_INCLUDE_DIRS})


### PR DESCRIPTION
Some issues with rocBLAS validation on recent drier versions.
Still compatible with rocBLAS 5.2 release. For now, force the older version