### PR TITLE
Hotfixes from release/rocm-rel-5.3 at release 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log for rocWMMA
 Full documentation for rocWMMA is available at [rocwmma.readthedocs.io](https://rocwmma.readthedocs.io/en/latest/).
 ## rocWMMA 0.8 for ROCm 5.3.0
-## Added
+### Added
 - Added runtime checks to disable tests on non-target GPUS
 - Added workgroup aware gemm kernels
 - Added workgroup aware validation and benchmark test suite


### PR DESCRIPTION
This is an autogenerated PR.
 This is intended to pull any hotfixes for ROCm release 5.3.0 (including changelogs and documentation) back into develop.