### PR TITLE
Fix wmma validation accuracy

### DIFF
--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -143,6 +143,43 @@ namespace rocwmma
                 it1++;
             }
         }
+
+        template <typename DataT, uint32_t VecSize>
+        __host__ __device__ static void exec(VecT<DataT, VecSize>& src0)
+        {
+            auto it0 = makeVectorIterator(src0).begin();
+            static_assert(decltype(it0)::range() == VecSize,
+                          "VecSize inconsistent with iterator range");
+
+            // Loop through entire vector
+#pragma unroll
+            for(uint32_t i = 0; i < VecSize; ++i)
+            {
+                *it0 = BlendFunc::exec(*it0, *it0);
+                it0++;
+            }
+        }
+
+        template <typename DataT, uint32_t VecSize>
+        __host__ __device__ static auto exec(VecT<DataT, VecSize> const& src0)
+        {
+            VecT<DataT, VecSize> result;
+            auto const           itR = makeVectorIterator(src0).begin();
+            auto                 itW = makeVectorIterator(result).begin();
+            static_assert(decltype(itR)::range() == VecSize,
+                          "VecSize inconsistent with iterator range");
+
+            // Loop through entire vector
+#pragma unroll
+            for(uint32_t i = 0; i < VecSize; ++i)
+            {
+                *itW = BlendFunc::exec(*itR, *itR);
+                itR++;
+                itW++;
+            }
+
+            return result;
+        }
     };
 
 } // namespace rocwmma

--- a/library/include/rocwmma/internal/constants.hpp
+++ b/library/include/rocwmma/internal/constants.hpp
@@ -30,6 +30,7 @@
 
 namespace rocwmma
 {
+
 #if ROCWMMA_WAVE64_MODE
     static constexpr uint32_t AMDGCN_WAVE_SIZE = 64u;
 #elif ROCWMMA_WAVE32_MODE
@@ -45,10 +46,6 @@ namespace rocwmma
     static constexpr uint32_t AMDGCN_LDS_MAX_SIZE_BYTES    = 65536u;
     static constexpr uint32_t AMDGCN_CACHE_LINE_SIZE_BYTES = 64u;
     static constexpr uint32_t AMDGCN_DWORD_SIZE_BYTES      = 4u;
-
-#if ROCWMMA_ARCH_NAVI
-    static constexpr uint32_t AMDGCN_CDNA_RDNA_WAVE_RATIO = 2u;
-#endif
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/permute.hpp
+++ b/library/include/rocwmma/internal/permute.hpp
@@ -109,6 +109,26 @@ namespace rocwmma
                 it++;
             }
         }
+
+        template <typename DataT, uint32_t VecSize>
+        __host__ __device__ static auto exec(VecT<DataT, VecSize> const& src, uint32_t laneId)
+        {
+            VecT<DataT, VecSize> result;
+            auto                 itW = makeVectorIterator(result).begin();
+            auto const           itR = makeVectorIterator(src).begin();
+            static_assert(decltype(itW)::range() == VecSize,
+                          "VecSize inconsistent with iterator range");
+
+            // Loop through entire vector
+#pragma unroll
+            for(uint32_t i = 0; i < VecSize; ++i)
+            {
+                *itW = PermuteFunc::exec(*itR, PermuteOp::threadCtrl(laneId));
+                itW++;
+                itR++;
+            }
+            return result;
+        }
     };
 
 } // namespace rocwmma

--- a/library/include/rocwmma/internal/vector_iterator.hpp
+++ b/library/include/rocwmma/internal/vector_iterator.hpp
@@ -27,8 +27,8 @@ namespace rocwmma
 
         struct iterator
         {
-            RefVecT const& mRef;
-            uint32_t       mIdx;
+            RefVecT const&   mRef;
+            mutable uint32_t mIdx;
 
             struct Traits
             {
@@ -68,37 +68,37 @@ namespace rocwmma
                 return reinterpret_cast<ItVecT*>(&const_cast<RefVecT&>(mRef))[mIdx];
             }
 
-            __HOST_DEVICE__ inline iterator& operator++()
+            __HOST_DEVICE__ inline iterator const& operator++() const
             {
                 mIdx++;
                 return *this;
             }
-            __HOST_DEVICE__ inline iterator operator++(int)
+            __HOST_DEVICE__ inline iterator operator++(int) const
             {
                 auto retval = *this;
                 ++mIdx;
                 return retval;
             }
 
-            __HOST_DEVICE__ inline iterator& operator--()
+            __HOST_DEVICE__ inline iterator const& operator--() const
             {
                 mIdx--;
                 return *this;
             }
-            __HOST_DEVICE__ inline iterator operator--(int)
+            __HOST_DEVICE__ inline iterator operator--(int) const
             {
                 auto retval = *this;
                 --mIdx;
                 return retval;
             }
 
-            __HOST_DEVICE__ inline iterator& operator+=(int i)
+            __HOST_DEVICE__ inline iterator const& operator+=(int i) const
             {
                 mIdx += i;
                 return *this;
             }
 
-            __HOST_DEVICE__ inline iterator& operator-=(int i)
+            __HOST_DEVICE__ inline iterator const& operator-=(int i) const
             {
                 mIdx -= i;
                 return *this;

--- a/library/include/rocwmma/internal/wmma.hpp
+++ b/library/include/rocwmma/internal/wmma.hpp
@@ -26,6 +26,7 @@
 #ifndef ROCWMMA_WMMA_HPP
 #define ROCWMMA_WMMA_HPP
 
+#include "permute.hpp"
 #include "vector.hpp"
 #include "vector_iterator.hpp"
 
@@ -78,19 +79,13 @@ namespace rocwmma
             && (BlockM == 16) && (BlockN == 16) && (BlockK >= 16) // 16 block size only
             >::type>
     {
+        // Functional backend
+        using WMMA = detail::amdgcn_wmma<InputT, ComputeT, BlockM, BlockN>;
+
         // Full-fragment IO traits
         using IOTraitsA   = IOTraits<BlockM, BlockK, InputT>;
         using IOTraitsB   = IOTraits<BlockK, BlockN, InputT>;
         using IOTraitsAcc = IOTraits<BlockM, BlockN, ComputeT>;
-
-        // Functional
-        using WMMA = detail::amdgcn_wmma<InputT, ComputeT, BlockM, BlockN>;
-
-        // Per-WMMA iterative vector requirements
-        using VecTraitsA = VecTraits<typename WMMA::Traits::ARegsT>;
-        using VecTraitsB = VecTraits<typename WMMA::Traits::BRegsT>;
-        using VecTraitsC = VecTraits<typename WMMA::Traits::CRegsT>;
-        using VecTraitsD = VecTraits<typename WMMA::Traits::DRegsT>;
 
         struct Traits
         {
@@ -98,139 +93,78 @@ namespace rocwmma
             {
                 WmmaCount = BlockK / WMMA::Traits::KPerWmma,
                 MinK      = WMMA::Traits::KPerWmma,
-
-                // WMMA instructions need to duplicate inputs and therefore
-                // must double fragment size.
-                WmmaInputMultiplier = 2u
             };
-
-            // Create full-fragment vector sizes
-            using ARegsT = typename VecTraitsA::template VecT<typename VecTraitsA::DataT,
-                                                              WmmaCount * VecTraitsA::size()
-                                                                  / WmmaInputMultiplier>;
-            using BRegsT = typename VecTraitsB::template VecT<typename VecTraitsB::DataT,
-                                                              WmmaCount * VecTraitsB::size()
-                                                                  / WmmaInputMultiplier>;
-            using CRegsT = typename VecTraitsC::template VecT<>;
-            using DRegsT = typename VecTraitsD::template VecT<>;
-
-            // Create per-wmma fragment vector sizes
-            using ARegsTPWmma =
-                typename VecTraitsA::template VecT<typename VecTraitsA::DataT,
-                                                   VecTraitsA::size() / WmmaInputMultiplier>;
-            using BRegsTPWmma =
-                typename VecTraitsB::template VecT<typename VecTraitsB::DataT,
-                                                   VecTraitsB::size() / WmmaInputMultiplier>;
 
             // Sanity checks
             static_assert(BlockK >= MinK, "BlockK is not a minimum of MinK");
             static_assert(BlockK % MinK == 0, "BlockK is not a multiple of MinK");
-
-            // A / B  and C / D types must match
-            static_assert(
-                std::is_same<typename VecTraitsA::DataT, typename VecTraitsB::DataT>::value,
-                "A and B registers must be of same type");
-            static_assert(
-                std::is_same<typename VecTraitsC::DataT, typename VecTraitsD::DataT>::value,
-                "C and D registers must be of same type");
-
-            // Full fragment counts must match packed IO counts
-            // WMMA expects packed elements
-            static_assert(VecTraits<ARegsT>::size() == IOTraitsA::PackedSize,
-                          "Unexpected packed vector size for A");
-            static_assert(VecTraits<BRegsT>::size() == IOTraitsB::PackedSize,
-                          "Unexpected packed vector size for B");
-            static_assert(VecTraits<CRegsT>::size() == IOTraitsAcc::PackedSize,
-                          "Unexpected packed vector size for C");
-            static_assert(VecTraits<DRegsT>::size() == IOTraitsAcc::PackedSize,
-                          "Unexpected packed vector size for D");
         };
 
-        __device__ static inline auto exec(typename Traits::ARegsT const& regsA,
-                                           typename Traits::BRegsT const& regsB,
-                                           typename Traits::CRegsT const& regsC) ->
-            typename Traits::DRegsT
-        {
-            typename Traits::DRegsT result = regsC;
+        // Per-WMMA iterative vector requirements
+        using VecTraitsA = VecTraits<typename WMMA::Traits::ARegsT>;
+        using VecTraitsB = VecTraits<typename WMMA::Traits::BRegsT>;
+        using VecTraitsC = VecTraits<typename WMMA::Traits::CRegsT>;
+        using VecTraitsD = VecTraits<typename WMMA::Traits::DRegsT>;
 
-            // Iterate over WMMA input requirements
-            auto aIt = makeVectorIterator<VecTraitsA::size() / Traits::WmmaInputMultiplier>(regsA)
-                           .begin();
-            auto bIt = makeVectorIterator<VecTraitsB::size() / Traits::WmmaInputMultiplier>(regsB)
-                           .begin();
+        // amdgcn backend requires duplicated packed inputs A / B, and unpacked accumulator
+        static_assert(VecTraitsA::size() * Traits::WmmaCount == IOTraitsA::PackedSize * 2u,
+                      "WMMA backend input size mismatch");
+        static_assert(VecTraitsB::size() * Traits::WmmaCount == IOTraitsB::PackedSize * 2u,
+                      "WMMA backend input size mismatch");
+        static_assert(VecTraitsC::size() == IOTraitsAcc::UnpackedSize,
+                      "WMMA backend input size mismatch");
+
+        template <typename InputARegsT, typename InputBRegsT, typename InputCRegsT>
+        __device__ static inline auto
+            exec(InputARegsT const& regsA, InputBRegsT const& regsB, InputCRegsT const& regsC)
+        {
+
+            // Inputs from outside will come in as fully packed
+            static_assert(VecTraits<InputARegsT>::size() == IOTraitsA::PackedSize,
+                          "WMMA input size mismatch");
+            static_assert(VecTraits<InputBRegsT>::size() == IOTraitsB::PackedSize,
+                          "WMMA input size mismatch");
+            static_assert(VecTraits<InputCRegsT>::size() == IOTraitsAcc::PackedSize,
+                          "WMMA input size mismatch");
+
+            // Unpack incoming C
+            auto accumulatorResult = Unpack<ComputeT, VecTraits<InputCRegsT>::size()>::exec(regsC);
+
+            // Iterate over packed WMMA inputs
+            auto const aIt = makeVectorIterator<VecTraitsA::size() / 2u>(regsA).begin();
+            auto const bIt = makeVectorIterator<VecTraitsB::size() / 2u>(regsB).begin();
 
             // Accumulate over WMMA count
 #pragma unroll
-            for(unsigned i = 0; i < Traits::WmmaCount; i++)
+            for(uint32_t i = 0; i < Traits::WmmaCount; i++)
             {
-                //Duplicate the uppper/lower input for register A
-                typename Traits::ARegsTPWmma regsAUpper(*aIt);
-                typename Traits::ARegsTPWmma regsALower(*aIt);
+                // Create WMMA input registers
+                typename WMMA::Traits::ARegsT regsA_Wmma;
+                typename WMMA::Traits::BRegsT regsB_Wmma;
 
-                //Create and initialize Wmma input A register
-                typename WMMA::Traits::ARegsT regsA_Wmma(InputT(0));
+                // Make iterators to store the duplication result
+                auto wmmaItA = makeVectorIterator<VecTraitsA::size() / 2u>(regsA_Wmma).begin();
+                auto wmmaItB = makeVectorIterator<VecTraitsA::size() / 2u>(regsB_Wmma).begin();
 
-                //Iterators for upper half and lower half of wmma registers
-                auto upperSrcAIt = makeVectorIterator(regsAUpper).begin();
-                auto lowerSrcAIt = makeVectorIterator(regsALower).begin();
+                // Duplicate the upper/lower inputs
+                // Lower has even rows
+                // Upper has odd rows
+                (*wmmaItA) = Permute<PermuteOps::BlockBCast16<0>>::exec(*aIt, detail::laneId());
+                wmmaItA++;
+                (*wmmaItA) = Permute<PermuteOps::BlockBCast16<1>>::exec(*aIt, detail::laneId());
 
-                static_assert(upperSrcAIt.range() == lowerSrcAIt.range(),
-                              "Upper and Lower register size should be equal");
+                (*wmmaItB) = Permute<PermuteOps::BlockBCast16<0>>::exec(*bIt, detail::laneId());
+                wmmaItB++;
+                (*wmmaItB) = Permute<PermuteOps::BlockBCast16<1>>::exec(*bIt, detail::laneId());
 
-                for(int j = 0; j < upperSrcAIt.range(); j++)
-                {
-                    Permute<PermuteOps::BlockBCast16<0>>::exec(*lowerSrcAIt, detail::laneId());
-                    Permute<PermuteOps::BlockBCast16<1>>::exec(*upperSrcAIt, detail::laneId());
-                    upperSrcAIt++;
-                    lowerSrcAIt++;
-                }
-
-                // update the src and dst iterators after data operation
-                auto dstAIt = makeVectorIterator<VecTraitsA::size() / Traits::WmmaInputMultiplier>(
-                                  regsA_Wmma)
-                                  .begin();
-
-                (*dstAIt) = regsAUpper;
-                dstAIt++;
-                (*dstAIt) = regsALower;
-
-                //Duplicate the uppper/lower input for register B
-                typename Traits::BRegsTPWmma regsBUpper(*bIt);
-                typename Traits::BRegsTPWmma regsBLower(*bIt);
-
-                //Create and initialize Wmma input B register
-                typename WMMA::Traits::BRegsT regsB_Wmma(InputT(0));
-
-                //Iterators for upper half and lower half of wmma registers
-                auto upperSrcBIt = makeVectorIterator(regsBUpper).begin();
-                auto lowerSrcBIt = makeVectorIterator(regsBLower).begin();
-
-                static_assert(upperSrcBIt.range() == lowerSrcBIt.range(),
-                              "Upper and Lower register size should be equal");
-
-                for(int j = 0; j < upperSrcBIt.range(); j++)
-                {
-                    Permute<PermuteOps::BlockBCast16<0>>::exec(*lowerSrcBIt, detail::laneId());
-                    Permute<PermuteOps::BlockBCast16<1>>::exec(*upperSrcBIt, detail::laneId());
-                    upperSrcBIt++;
-                    lowerSrcBIt++;
-                }
-
-                auto dstBIt = makeVectorIterator<VecTraitsB::size() / Traits::WmmaInputMultiplier>(
-                                  regsB_Wmma)
-                                  .begin();
-
-                // update the src and dst iterators after data operation
-                (*dstBIt) = regsBUpper;
-                dstBIt++;
-                (*dstBIt) = regsBLower;
-
-                result = WMMA::exec(regsA_Wmma, regsB_Wmma, result);
+                accumulatorResult = WMMA::exec(regsA_Wmma, regsB_Wmma, accumulatorResult);
 
                 aIt++;
                 bIt++;
             }
-            return result;
+
+            return Pack<ComputeT, VecTraits<decltype(accumulatorResult)>::size()>::exec(
+                accumulatorResult);
         }
     };
 } // namespace rocwmma

--- a/library/include/rocwmma/internal/wmma_impl.hpp
+++ b/library/include/rocwmma/internal/wmma_impl.hpp
@@ -97,7 +97,11 @@ namespace rocwmma
             {
                 typename Traits::DRegsT result;
                 result.data = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32(
-                    regsA.data, regsB.data, regsC.data, 0)};
+                    regsA.data,
+                    regsB.data,
+                    regsC.data,
+                    0 // Result in lower 16 bits of accumulator
+                    )};
                 return result;
             }
         };
@@ -165,7 +169,11 @@ namespace rocwmma
             {
                 typename Traits::DRegsT result;
                 result.data = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32(
-                    regsA.data, regsB.data, regsC.data, 1)};
+                    regsA.data,
+                    regsB.data,
+                    regsC.data,
+                    0 // Result in lower 16 bits of accumulator
+                    )};
                 return result;
             }
         };


### PR DESCRIPTION
- wmma uses packed inputs
- wmma uses unpacked accumulator
- Simplify the iteration by adding more vector support for cross lane ops
- Adjust const-ness of vector iterators to imply internal reference access.
- Navi register ratio is localized to WMMA, therefore we don't need visibility to rest of API.