### PR TITLE
Move to device query for hardware props

### DIFF
--- a/test/hip_device.cpp
+++ b/test/hip_device.cpp
@@ -34,6 +34,8 @@ namespace rocwmma
         , mGcnArch(hipGcnArch_t::UNSUPPORTED_ARCH)
         , mWarpSize(hipWarpSize_t::UNSUPPORTED_WARP_SIZE)
         , mSharedMemSize(0)
+        , mCuCount(0)
+        , mMaxFreqMhz(0)
     {
         CHECK_HIP_ERROR(hipGetDevice(&mHandle));
         CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
@@ -72,6 +74,8 @@ namespace rocwmma
         }
 
         mSharedMemSize = mProps.sharedMemPerBlock;
+        mCuCount       = mProps.multiProcessorCount;
+        mMaxFreqMhz    = static_cast<int>(static_cast<double>(mProps.clockRate) / 1000.0);
     }
 
     hipDevice_t HipDevice::getDeviceHandle() const
@@ -102,6 +106,16 @@ namespace rocwmma
     int HipDevice::sharedMemSize() const
     {
         return mSharedMemSize;
+    }
+
+    int HipDevice::cuCount() const
+    {
+        return mCuCount;
+    }
+
+    int HipDevice::maxFreqMhz() const
+    {
+        return mMaxFreqMhz;
     }
 
     // Need to check the host device target support statically before hip modules attempt

--- a/test/hip_device.hpp
+++ b/test/hip_device.hpp
@@ -68,8 +68,9 @@ namespace rocwmma
         hipGcnArch_t    getGcnArch() const;
 
         int warpSize() const;
-
         int sharedMemSize() const;
+        int cuCount() const;
+        int maxFreqMhz() const;
 
         template <typename InputT>
         double peakGFlopsPerSec() const;
@@ -81,6 +82,8 @@ namespace rocwmma
         hipGcnArch_t    mGcnArch;
         int             mWarpSize;
         int             mSharedMemSize;
+        int             mCuCount;
+        int             mMaxFreqMhz;
     };
 
     template <typename InputT>
@@ -90,11 +93,11 @@ namespace rocwmma
         switch(mGcnArch)
         {
         case hipGcnArch_t::GFX908:
-            result = calculatePeakGFlopsPerSec<InputT, MI100>(1087);
+            result = calculatePeakGFlopsPerSec<InputT, MI100>(mMaxFreqMhz, mCuCount);
             break;
 
         case hipGcnArch_t::GFX90A:
-            result = calculatePeakGFlopsPerSec<InputT, MI200>(985);
+            result = calculatePeakGFlopsPerSec<InputT, MI200>(mMaxFreqMhz, mCuCount);
             break;
         default:;
         }

--- a/test/performance.hpp
+++ b/test/performance.hpp
@@ -236,27 +236,6 @@ namespace rocwmma
     {
     };
 
-    template <typename GfxArch>
-    struct HardwareTraits;
-
-    template <>
-    struct HardwareTraits<MI100>
-    {
-        enum : uint32_t
-        {
-            CuCount = 120,
-        };
-    };
-
-    template <>
-    struct HardwareTraits<MI200>
-    {
-        enum : uint32_t
-        {
-            CuCount = 110,
-        };
-    };
-
     inline double calculateGFlops(uint32_t m, uint32_t n, uint32_t k)
     {
         return 2.0 * static_cast<double>(m) * static_cast<double>(n) * static_cast<double>(k)
@@ -270,13 +249,11 @@ namespace rocwmma
 
     template <typename InputT,
               typename GfxArch,
-              template <typename, typename> class PerfTraits = rocwmma::MfmaPerfTraits,
-              template <typename> class HardwareTraits       = rocwmma::HardwareTraits>
-    inline double calculatePeakGFlopsPerSec(uint32_t freqMHz)
+              template <typename, typename> class PerfTraits = rocwmma::MfmaPerfTraits>
+    inline double calculatePeakGFlopsPerSec(uint32_t freqMHz, uint32_t cuCount)
     {
         return static_cast<double>(PerfTraits<GfxArch, InputT>::Multiplier)
-               * static_cast<double>(HardwareTraits<GfxArch>::CuCount)
-               * static_cast<double>(freqMHz) * 1.0e-3;
+               * static_cast<double>(cuCount) * static_cast<double>(freqMHz) * 1.0e-3;
     }
 
 } // namespace rocwmma


### PR DESCRIPTION
- Remove hw meta-data for CuCount and frequency.
- Replace with hip device query.
- Performance data must be collected on devices with fixed frequency.