### PR TITLE
Add threadblock as a multiple of warpsize

### DIFF
--- a/test/unit/test/cross_lane_ops_test/blend_unpack_byte_hi.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_unpack_byte_hi.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/blend_unpack_byte_hi_lo.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_unpack_byte_hi_lo.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/blend_unpack_byte_lo.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_unpack_byte_lo.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/blend_unpack_word_hi.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_unpack_word_hi.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/blend_unpack_word_lo.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_unpack_word_lo.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/blend_zip_byte.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_zip_byte.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/blend_zip_word.cpp
+++ b/test/unit/test/cross_lane_ops_test/blend_zip_word.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_bcast_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_bcast_16.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_bcast_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_bcast_2.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_bcast_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_bcast_4.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_reverse_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_reverse_16.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_reverse_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_reverse_2.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_reverse_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_reverse_4.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_reverse_8.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_reverse_8.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_l2.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_l2.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_l4.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_l4.cpp
@@ -63,14 +63,15 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
-        }
+             // clang-format on
+       }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_r16.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_r16.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_r2.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_r2.cpp
@@ -63,14 +63,15 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
-        }
+             // clang-format on
+       }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_r4.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_r4.cpp
@@ -63,14 +63,15 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
-        }
+             // clang-format on
+       }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_wave_l1.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_wave_l1.cpp
@@ -63,14 +63,15 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
-        }
+             // clang-format on
+       }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {

--- a/test/unit/test/cross_lane_ops_test/dpp_rotate_wave_r1.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_rotate_wave_r1.cpp
@@ -63,14 +63,15 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
-        }
+             // clang-format on
+       }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {

--- a/test/unit/test/cross_lane_ops_test/dpp_shift_l16.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_shift_l16.cpp
@@ -63,14 +63,15 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
-        }
+             // clang-format on
+       }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {

--- a/test/unit/test/cross_lane_ops_test/dpp_shift_r16.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_shift_r16.cpp
@@ -63,13 +63,13 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
-            // clang-format on
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()

--- a/test/unit/test/cross_lane_ops_test/dpp_shift_wave_l1.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_shift_wave_l1.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_shift_wave_r1.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_shift_wave_r1.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_shuffle_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_shuffle_2.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_shuffle_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_shuffle_4.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_swap_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_swap_2.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_wfall_bcast_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_wfall_bcast_16.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/dpp_wfall_bcast_32.cpp
+++ b/test/unit/test/cross_lane_ops_test/dpp_wfall_bcast_32.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/permute_block_bcast_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/permute_block_bcast_16.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/permute_block_bcast_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/permute_block_bcast_2.cpp
@@ -60,11 +60,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/permute_block_bcast_32.cpp
+++ b/test/unit/test/cross_lane_ops_test/permute_block_bcast_32.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/permute_block_bcast_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/permute_block_bcast_4.cpp
@@ -60,11 +60,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/permute_block_bcast_8.cpp
+++ b/test/unit/test/cross_lane_ops_test/permute_block_bcast_8.cpp
@@ -60,11 +60,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_bcast_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_bcast_16.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_bcast_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_bcast_2.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_bcast_32.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_bcast_32.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_bcast_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_bcast_4.cpp
@@ -60,11 +60,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_bcast_8.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_bcast_8.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_reverse_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_reverse_16.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_reverse_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_reverse_2.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_reverse_32.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_reverse_32.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_reverse_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_reverse_4.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_reverse_8.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_reverse_8.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_l16.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_l16.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_l2.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_l2.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_l32.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_l32.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_l4.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_l4.cpp
@@ -60,11 +60,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_l8.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_l8.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_r16.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_r16.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_r2.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_r2.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_r32.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_r32.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_r4.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_r4.cpp
@@ -60,11 +60,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_rotate_r8.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_rotate_r8.cpp
@@ -64,11 +64,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_shuffle_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_shuffle_2.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_shuffle_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_shuffle_4.cpp
@@ -63,11 +63,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_swap_16.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_swap_16.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_swap_2.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_swap_2.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_swap_4.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_swap_4.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/cross_lane_ops_test/swizzle_swap_8.cpp
+++ b/test/unit/test/cross_lane_ops_test/swizzle_swap_8.cpp
@@ -57,11 +57,12 @@ namespace rocwmma
         // Must be TBlockY must be 1.
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return {
-                        {64, 1},
-                        {128, 1},
-                        {256, 1}
+                        {warpSize, 1},
+                        {warpSize * 2, 1},
+                        {warpSize * 4, 1}
                     };
             // clang-format on
         }

--- a/test/unit/test/io_shape_test/io_shape_128.cpp
+++ b/test/unit/test/io_shape_test/io_shape_128.cpp
@@ -58,8 +58,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_shape_test/io_shape_16.cpp
+++ b/test/unit/test/io_shape_test/io_shape_16.cpp
@@ -58,8 +58,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_shape_test/io_shape_256.cpp
+++ b/test/unit/test/io_shape_test/io_shape_256.cpp
@@ -58,8 +58,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_shape_test/io_shape_32.cpp
+++ b/test/unit/test/io_shape_test/io_shape_32.cpp
@@ -58,8 +58,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_shape_test/io_shape_64.cpp
+++ b/test/unit/test/io_shape_test/io_shape_64.cpp
@@ -58,8 +58,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_traits_test/io_traits_128.cpp
+++ b/test/unit/test/io_traits_test/io_traits_128.cpp
@@ -56,8 +56,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_traits_test/io_traits_16.cpp
+++ b/test/unit/test/io_traits_test/io_traits_16.cpp
@@ -56,8 +56,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_traits_test/io_traits_256.cpp
+++ b/test/unit/test/io_traits_test/io_traits_256.cpp
@@ -56,8 +56,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-        return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_traits_test/io_traits_32.cpp
+++ b/test/unit/test/io_traits_test/io_traits_32.cpp
@@ -56,8 +56,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/test/io_traits_test/io_traits_64.cpp
+++ b/test/unit/test/io_traits_test/io_traits_64.cpp
@@ -56,8 +56,9 @@ namespace rocwmma
 
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {64, 1} };
+            return { {warpSize, 1} };
             // clang-format on
         }
 


### PR DESCRIPTION
Modify the following unit tests to have threadblock as a multiple of warp size
* cross_lane_ops_test
* io_shape_test
* io_traits_test