### PR TITLE
__HOST_DEVICE__ symbol inclusion

### DIFF
--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -104,13 +104,13 @@ namespace rocwmma
                       "BlendOp is unsupported");
 
         template <typename DataT>
-        __host__ __device__ static inline DataT exec(DataT const& src0, DataT const& src1)
+        __HOST_DEVICE__ static inline DataT exec(DataT const& src0, DataT const& src1)
         {
             return BlendFunc::exec(src0, src1);
         }
 
         template <typename DataT, uint32_t VecSize>
-        __host__ __device__ static void exec(VecT<DataT, VecSize>& src0, DataT const& src1)
+        __HOST_DEVICE__ static void exec(VecT<DataT, VecSize>& src0, DataT const& src1)
         {
             auto it = makeVectorIterator(src0).begin();
             static_assert(decltype(it)::range() == VecSize,
@@ -126,8 +126,8 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        __host__ __device__ static void exec(VecT<DataT, VecSize>&       src0,
-                                             VecT<DataT, VecSize> const& src1)
+        __HOST_DEVICE__ static void exec(VecT<DataT, VecSize>&       src0,
+                                         VecT<DataT, VecSize> const& src1)
         {
             auto it0 = makeVectorIterator(src0).begin();
             auto it1 = makeVectorIterator(src1).begin();
@@ -145,7 +145,7 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        __host__ __device__ static void exec(VecT<DataT, VecSize>& src0)
+        __HOST_DEVICE__ static void exec(VecT<DataT, VecSize>& src0)
         {
             auto it0 = makeVectorIterator(src0).begin();
             static_assert(decltype(it0)::range() == VecSize,
@@ -161,7 +161,7 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        __host__ __device__ static auto exec(VecT<DataT, VecSize> const& src0)
+        __HOST_DEVICE__ static auto exec(VecT<DataT, VecSize> const& src0)
         {
             VecT<DataT, VecSize> result;
             auto const           itR = makeVectorIterator(src0).begin();

--- a/library/include/rocwmma/internal/permute.hpp
+++ b/library/include/rocwmma/internal/permute.hpp
@@ -83,19 +83,19 @@ namespace rocwmma
                       "PermuteOp is unsupported");
 
         template <typename DataT>
-        __host__ __device__ static DataT exec(DataT const& src, uint32_t laneId)
+        __HOST_DEVICE__ static DataT exec(DataT const& src, uint32_t laneId)
         {
             return PermuteFunc::exec(src, PermuteOp::threadCtrl(laneId));
         }
 
         template <typename DataT>
-        __host__ __device__ static void exec(DataT& src, uint32_t laneId)
+        __HOST_DEVICE__ static void exec(DataT& src, uint32_t laneId)
         {
             src = PermuteFunc::exec(src, PermuteOp::threadCtrl(laneId));
         }
 
         template <typename DataT, uint32_t VecSize>
-        __host__ __device__ static void exec(VecT<DataT, VecSize>& src, uint32_t laneId)
+        __HOST_DEVICE__ static void exec(VecT<DataT, VecSize>& src, uint32_t laneId)
         {
             auto it = makeVectorIterator(src).begin();
             static_assert(decltype(it)::range() == VecSize,
@@ -111,7 +111,7 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        __host__ __device__ static auto exec(VecT<DataT, VecSize> const& src, uint32_t laneId)
+        __HOST_DEVICE__ static auto exec(VecT<DataT, VecSize> const& src, uint32_t laneId)
         {
             VecT<DataT, VecSize> result;
             auto                 itW = makeVectorIterator(result).begin();

--- a/library/include/rocwmma/internal/permute_impl.hpp
+++ b/library/include/rocwmma/internal/permute_impl.hpp
@@ -44,7 +44,7 @@ namespace rocwmma
 
         public:
             // Calculate the read element based on thread position.
-            __host__ __device__ static inline uint32_t threadCtrl(uint32_t threadId)
+            __HOST_DEVICE__ static inline uint32_t threadCtrl(uint32_t threadId)
             {
                 // Make sure that the threadId is within range
                 auto tIdx = threadId % BlockSize;

--- a/library/include/rocwmma/internal/types_ext.hpp
+++ b/library/include/rocwmma/internal/types_ext.hpp
@@ -130,56 +130,54 @@ namespace std
     ///////////////////////////////////////////////////////////
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::epsilon() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t
+        numeric_limits<rocwmma::float16_t>::epsilon() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x1400));
         return eps.f16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::infinity() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t
+        numeric_limits<rocwmma::float16_t>::infinity() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7C00));
         return eps.f16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::lowest() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t
+        numeric_limits<rocwmma::float16_t>::lowest() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0xFBFF));
         return eps.f16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::max() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t numeric_limits<rocwmma::float16_t>::max() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7BFF));
         return eps.f16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::min() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t numeric_limits<rocwmma::float16_t>::min() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x0400));
         return eps.f16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::quiet_NaN() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t
+        numeric_limits<rocwmma::float16_t>::quiet_NaN() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7FFF));
         return eps.f16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::float16_t
-             numeric_limits<rocwmma::float16_t>::signaling_NaN() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::float16_t
+        numeric_limits<rocwmma::float16_t>::signaling_NaN() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7DFF));
         return eps.f16;
@@ -190,56 +188,56 @@ namespace std
     ///////////////////////////////////////////////////////////
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::epsilon() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::epsilon() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x1400));
         return eps.h16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::infinity() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::infinity() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7C00));
         return eps.h16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::lowest() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::lowest() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0xFBFF));
         return eps.h16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::max() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::max() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7BFF));
         return eps.h16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::min() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::min() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x0400));
         return eps.h16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::quiet_NaN() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::quiet_NaN() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7FFF));
         return eps.h16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::hfloat16_t
-             numeric_limits<rocwmma::hfloat16_t>::signaling_NaN() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::hfloat16_t
+        numeric_limits<rocwmma::hfloat16_t>::signaling_NaN() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7DFF));
         return eps.h16;
@@ -250,56 +248,56 @@ namespace std
     ///////////////////////////////////////////////////////////
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::epsilon() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::epsilon() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x3C00));
         return eps.b16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::infinity() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::infinity() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7F80));
         return eps.b16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::lowest() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::lowest() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0xFF7F));
         return eps.b16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::max() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::max() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7F7F));
         return eps.b16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::min() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::min() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x007F));
         return eps.b16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::quiet_NaN() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::quiet_NaN() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7FC0));
         return eps.b16;
     }
 
     template <>
-    __host__ __device__ constexpr rocwmma::bfloat16_t
-             numeric_limits<rocwmma::bfloat16_t>::signaling_NaN() noexcept
+    __HOST_DEVICE__ constexpr rocwmma::bfloat16_t
+        numeric_limits<rocwmma::bfloat16_t>::signaling_NaN() noexcept
     {
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7FC0));
         return eps.b16;

--- a/library/include/rocwmma/internal/utils.hpp
+++ b/library/include/rocwmma/internal/utils.hpp
@@ -38,19 +38,19 @@ namespace rocwmma
     /// Element-wise access of vectors in constexpr is forbidden.   ///
     ///////////////////////////////////////////////////////////////////
     template <uint32_t Idx, typename DataT, uint32_t VecSize>
-    __host__ __device__ constexpr inline DataT& get(HIP_vector_type<DataT, VecSize>& v)
+    __HOST_DEVICE__ constexpr inline DataT& get(HIP_vector_type<DataT, VecSize>& v)
     {
         return reinterpret_cast<DataT*>(&v.data)[Idx];
     }
 
     template <uint32_t Idx, typename DataT, uint32_t VecSize>
-    __host__ __device__ constexpr inline DataT get(HIP_vector_type<DataT, VecSize> const& v)
+    __HOST_DEVICE__ constexpr inline DataT get(HIP_vector_type<DataT, VecSize> const& v)
     {
         return v.data[Idx];
     }
 
     template <typename DataT>
-    __host__ __device__ constexpr inline auto swap(HIP_vector_type<DataT, 2> const& v)
+    __HOST_DEVICE__ constexpr inline auto swap(HIP_vector_type<DataT, 2> const& v)
     {
         return HIP_vector_type<DataT, 2>{get<1>(v), get<0>(v)};
     }
@@ -59,14 +59,13 @@ namespace rocwmma
     ///     non_native_vector_base<T, N> utility overrides          ///
     ///////////////////////////////////////////////////////////////////
     template <uint32_t Idx, typename DataT, uint32_t VecSize>
-    __host__ __device__ constexpr static inline DataT&
-        get(non_native_vector_base<DataT, VecSize>& v)
+    __HOST_DEVICE__ constexpr static inline DataT& get(non_native_vector_base<DataT, VecSize>& v)
     {
         return v[Idx];
     }
 
     template <uint32_t Idx, typename DataT, uint32_t VecSize>
-    __host__ __device__ constexpr static inline DataT
+    __HOST_DEVICE__ constexpr static inline DataT
         get(non_native_vector_base<DataT, VecSize> const& v)
     {
         return v[Idx];
@@ -74,7 +73,7 @@ namespace rocwmma
 
     // Unary swap only considered in 2d vectors.
     template <typename DataT>
-    __host__ __device__ constexpr static inline auto swap(non_native_vector_base<DataT, 2> const& v)
+    __HOST_DEVICE__ constexpr static inline auto swap(non_native_vector_base<DataT, 2> const& v)
     {
         return non_native_vector_base<DataT, 2>{get<1>(v), get<0>(v)};
     }
@@ -84,24 +83,24 @@ namespace rocwmma
     ///                                                             ///
     /// Note: Coord2d MUST be constexpr compatible                  ///
     ///////////////////////////////////////////////////////////////////
-    __host__ __device__ constexpr static inline auto make_coord2d(Coord2dDataT x, Coord2dDataT y)
+    __HOST_DEVICE__ constexpr static inline auto make_coord2d(Coord2dDataT x, Coord2dDataT y)
     {
         return Coord2d{x, y};
     }
 
-    __host__ __device__ constexpr static inline auto swap(Coord2d const& p)
+    __HOST_DEVICE__ constexpr static inline auto swap(Coord2d const& p)
     {
         return Coord2d{get<1>(p), get<0>(p)};
     }
 
-    __host__ __device__ constexpr static inline Coord2d operator*(Coord2d const& lhs,
-                                                                  Coord2d const& rhs)
+    __HOST_DEVICE__ constexpr static inline Coord2d operator*(Coord2d const& lhs,
+                                                              Coord2d const& rhs)
     {
         return make_coord2d(get<0>(lhs) * get<0>(rhs), get<1>(lhs) * get<1>(rhs));
     }
 
-    __host__ __device__ constexpr static inline Coord2d operator+(Coord2d const& lhs,
-                                                                  Coord2d const& rhs)
+    __HOST_DEVICE__ constexpr static inline Coord2d operator+(Coord2d const& lhs,
+                                                              Coord2d const& rhs)
     {
         return make_coord2d(get<0>(lhs) + get<0>(rhs), get<1>(lhs) + get<1>(rhs));
     }
@@ -137,15 +136,15 @@ namespace std
 {
     // Add, sub operators
     template <typename T>
-    __host__ __device__ constexpr static inline pair<T, T> operator+(pair<T, T> const& lhs,
-                                                                     pair<T, T> const& rhs)
+    __HOST_DEVICE__ constexpr static inline pair<T, T> operator+(pair<T, T> const& lhs,
+                                                                 pair<T, T> const& rhs)
     {
         return make_pair(get<0>(lhs) + get<0>(rhs), get<1>(lhs) + get<1>(rhs));
     }
 
     template <typename T>
-    __host__ __device__ constexpr static inline pair<T, T>& operator+=(pair<T, T>&       lhs,
-                                                                       pair<T, T> const& rhs)
+    __HOST_DEVICE__ constexpr static inline pair<T, T>& operator+=(pair<T, T>&       lhs,
+                                                                   pair<T, T> const& rhs)
     {
         get<0>(lhs) += get<0>(rhs);
         get<1>(lhs) += get<1>(rhs);
@@ -153,15 +152,15 @@ namespace std
     }
 
     template <typename T>
-    __host__ __device__ constexpr static inline pair<T, T> operator*(pair<T, T> const& lhs,
-                                                                     pair<T, T> const& rhs)
+    __HOST_DEVICE__ constexpr static inline pair<T, T> operator*(pair<T, T> const& lhs,
+                                                                 pair<T, T> const& rhs)
     {
         return make_pair(get<0>(lhs) * get<0>(rhs), get<1>(lhs) * get<1>(rhs));
     }
 
     template <typename T>
-    __host__ __device__ constexpr static inline pair<T, T>& operator*=(pair<T, T>&       lhs,
-                                                                       pair<T, T> const& rhs)
+    __HOST_DEVICE__ constexpr static inline pair<T, T>& operator*=(pair<T, T>&       lhs,
+                                                                   pair<T, T> const& rhs)
     {
         get<0>(lhs) *= get<0>(rhs);
         get<1>(lhs) *= get<1>(rhs);
@@ -169,15 +168,15 @@ namespace std
     }
 
     template <typename T>
-    __host__ __device__ constexpr static inline pair<T, T> operator-(pair<T, T> const& lhs,
-                                                                     pair<T, T> const& rhs)
+    __HOST_DEVICE__ constexpr static inline pair<T, T> operator-(pair<T, T> const& lhs,
+                                                                 pair<T, T> const& rhs)
     {
         return make_pair(get<0>(lhs) - get<0>(rhs), get<1>(lhs) - get<1>(rhs));
     }
 
     template <typename T>
-    __host__ __device__ constexpr static inline pair<T, T>& operator-=(pair<T, T>&       lhs,
-                                                                       pair<T, T> const& rhs)
+    __HOST_DEVICE__ constexpr static inline pair<T, T>& operator-=(pair<T, T>&       lhs,
+                                                                   pair<T, T> const& rhs)
     {
         get<0>(lhs) -= get<0>(rhs);
         get<1>(lhs) -= get<1>(rhs);


### PR DESCRIPTION
Modified \_\_host\_\_  \_\_device\_\_ usage to \_\_HOST\_DEVICE\_\_ for hipRTC which is defined as:
- \_\_device\_\_ when used in the hipRTC environment
- \_\_host\_\_ \_\_device\_\_ otherwise