### PR TITLE
Unit test guards

### DIFF
--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
@@ -68,30 +68,37 @@ namespace rocwmma
         enum struct Gfx9Predicates : bool
         {
             CostABTest
-            = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB)
-               <= 256u),
-            CostCTest     = ((uint32_t)TestTraits::Cost::TileC <= 256u),
-            CostDTest     = ((uint32_t)TestTraits::Cost::TileD <= 256u),
+            = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB) <= 256u),
+            CostCTest = ((uint32_t)TestTraits::Cost::TileC <= 256u),
+            CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
             // Must skip int8 tests on gfx9 for now
             IsInt8 = std::is_same<int8_t, InputT>::value,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8 && CostABTest && CostCTest && CostDTest)
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8
+                      && CostABTest && CostCTest && CostDTest)
         };
 
         enum struct Gfx11Predicates : bool
         {
+            IsFp16
+            = std::is_same<InputT, float16_t>::value || std::is_same<InputT, hfloat16_t>::value,
+            IsBf16    = std::is_same<InputT, hip_bfloat16>::value,
+            IsInt8    = std::is_same<InputT, int8_t>::value,
+            TypesTest = IsFp16 || IsBf16 || IsInt8,
+
             // AB inputs are duplicated, single buffered
             // C tiles are unpacked.
             CostABTest
             = ((2u * ((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB))
                <= 256u),
-            CostCTest     = ((2u * (uint32_t)TestTraits::Cost::TileC) <= 256u),
-            CostDTest     = ((uint32_t)TestTraits::Cost::TileD <= 256u),
+            CostCTest = ((2u * (uint32_t)TestTraits::Cost::TileC) <= 256u),
+            CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
+
             BlockSizeTest = ((BlockM == 16u) && (BlockN == 16u)),
 
-            Enable = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && CostABTest
-                      && CostCTest && CostDTest && BlockSizeTest)
+            Enable = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && TypesTest
+                      && CostABTest && CostCTest && CostDTest && BlockSizeTest)
         };
 
     public:

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_device_func.hpp
@@ -67,10 +67,16 @@ namespace rocwmma
     private:
         enum struct Gfx9Predicates : bool
         {
+            CostABTest
+            = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB)
+               <= 256u),
+            CostCTest     = ((uint32_t)TestTraits::Cost::TileC <= 256u),
+            CostDTest     = ((uint32_t)TestTraits::Cost::TileD <= 256u),
+
             // Must skip int8 tests on gfx9 for now
             IsInt8 = std::is_same<int8_t, InputT>::value,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8)
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8 && CostABTest && CostCTest && CostDTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
@@ -67,18 +67,24 @@ namespace rocwmma
         {
             // Must skip int8 tests on gfx9 for now
             CostABTest
-            = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB)
-               <= 256u),
-            CostCTest     = ((uint32_t)TestTraits::Cost::TileC <= 256u),
-            CostDTest     = ((uint32_t)TestTraits::Cost::TileD <= 256u),
+            = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB) <= 256u),
+            CostCTest = ((uint32_t)TestTraits::Cost::TileC <= 256u),
+            CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
             IsInt8 = std::is_same<int8_t, InputT>::value,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8 && CostABTest && CostCTest && CostDTest)
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8
+                      && CostABTest && CostCTest && CostDTest)
         };
 
         enum struct Gfx11Predicates : bool
         {
+            IsFp16
+            = std::is_same<InputT, float16_t>::value || std::is_same<InputT, hfloat16_t>::value,
+            IsBf16    = std::is_same<InputT, hip_bfloat16>::value,
+            IsInt8    = std::is_same<InputT, int8_t>::value,
+            TypesTest = IsFp16 || IsBf16 || IsInt8,
+
             // AB inputs are duplicated, single buffered
             // C tiles are unpacked.
             CostABTest
@@ -88,8 +94,8 @@ namespace rocwmma
             CostDTest     = ((uint32_t)TestTraits::Cost::TileD <= 256u),
             BlockSizeTest = ((BlockM == 16u) && (BlockN == 16u)),
 
-            Enable = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && CostABTest
-                      && CostCTest && CostDTest && BlockSizeTest)
+            Enable = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && TypesTest
+                      && CostABTest && CostCTest && CostDTest && BlockSizeTest)
         };
 
     public:

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_device_func.hpp
@@ -66,9 +66,15 @@ namespace rocwmma
         enum struct Gfx9Predicates : bool
         {
             // Must skip int8 tests on gfx9 for now
+            CostABTest
+            = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB)
+               <= 256u),
+            CostCTest     = ((uint32_t)TestTraits::Cost::TileC <= 256u),
+            CostDTest     = ((uint32_t)TestTraits::Cost::TileD <= 256u),
+
             IsInt8 = std::is_same<int8_t, InputT>::value,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8)
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8 && CostABTest && CostCTest && CostDTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_device_func.hpp
@@ -85,10 +85,18 @@ namespace rocwmma
 
         enum struct Gfx9Predicates : bool
         {
+            CostABTest
+            = ((2u * ((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB))
+               <= 256u),
+            CostAccTest   = ((uint32_t)TestTraits::Cost::TileC <= 256u),
+            CostTailTest  = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB
+                             + 2u * (uint32_t)TestTraits::Cost::TileD)
+                            <= 256u),
+
             // Must skip int8 tests on gfx9 for now
             IsInt8 = std::is_same<int8_t, InputT>::value,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8)
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8 && CostABTest && CostAccTest && CostTailTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_device_func.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_device_func.hpp
@@ -88,19 +88,26 @@ namespace rocwmma
             CostABTest
             = ((2u * ((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB))
                <= 256u),
-            CostAccTest   = ((uint32_t)TestTraits::Cost::TileC <= 256u),
-            CostTailTest  = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB
+            CostAccTest  = ((uint32_t)TestTraits::Cost::TileC <= 256u),
+            CostTailTest = (((uint32_t)TestTraits::Cost::TileA + (uint32_t)TestTraits::Cost::TileB
                              + 2u * (uint32_t)TestTraits::Cost::TileD)
                             <= 256u),
 
             // Must skip int8 tests on gfx9 for now
             IsInt8 = std::is_same<int8_t, InputT>::value,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8 && CostABTest && CostAccTest && CostTailTest)
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && !(bool)IsInt8
+                      && CostABTest && CostAccTest && CostTailTest)
         };
 
         enum struct Gfx11Predicates : bool
         {
+            IsFp16
+            = std::is_same<InputT, float16_t>::value || std::is_same<InputT, hfloat16_t>::value,
+            IsBf16    = std::is_same<InputT, hip_bfloat16>::value,
+            IsInt8    = std::is_same<InputT, int8_t>::value,
+            TypesTest = (IsFp16 || IsBf16) && !IsInt8,
+
             // AB inputs are duplicated, double buffered
             // Acc tiles are unpacked.
             // Tail requires A, B, C & D tiles + FMA
@@ -113,10 +120,8 @@ namespace rocwmma
                             <= 256u),
             BlockSizeTest = ((BlockM == 16u) && (BlockN == 16u)),
 
-            IsInt8 = std::is_same<int8_t, InputT>::value,
-
-            Enable = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && CostABTest
-                      && CostAccTest && CostTailTest && BlockSizeTest && !IsInt8)
+            Enable = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && TypesTest
+                      && CostABTest && CostAccTest && CostTailTest && BlockSizeTest)
         };
 
     public:

--- a/test/unit/detail/col_layout.hpp
+++ b/test/unit/detail/col_layout.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_COL_LAYOUT_HPP
 
 #include "device/col_layout.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -39,6 +40,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     public:
         ColLayoutKernel()        = default;
@@ -54,9 +58,11 @@ namespace rocwmma
 
             // Initialize data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
-            
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
+
             // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
             dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
@@ -66,7 +72,7 @@ namespace rocwmma
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            const int64_t sizeD        = Base::mM * Base::mN;
+            const int64_t sizeD = Base::mM * Base::mN;
 
             // Cache current kernel result from device
             dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
@@ -79,6 +85,43 @@ namespace rocwmma
                                                              Base::mM,
                                                              Base::mN,
                                                              errorTolerance);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
 
         typename Base::KernelFunc kernelImpl() const final

--- a/test/unit/detail/load_contamination.hpp
+++ b/test/unit/detail/load_contamination.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_LOAD_CONTAMINATION_HPP
 
 #include "device/load_contamination.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -39,6 +40,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     public:
         LoadContaminationKernel()          = default;
@@ -77,10 +81,13 @@ namespace rocwmma
                                    std::get<0>(paddedProbSize) * std::get<1>(paddedProbSize));
 
             // Initialize device output data with NaN
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
-            dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), Base::mM * Base::mN);
+            dataInstance->copyData(
+                dataInstance->deviceOut(), dataInstance->hostOut(), Base::mM * Base::mN);
         }
 
         void validateResultsImpl() final
@@ -104,6 +111,43 @@ namespace rocwmma
 
             // We want no contamination
             Base::mValidationResult = (result == 0);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
 
         virtual typename Base::KernelFunc kernelImpl() const = 0;

--- a/test/unit/detail/load_store_matrix_sync.hpp
+++ b/test/unit/detail/load_store_matrix_sync.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_LOAD_STORE_MATRIX_SYNC_HPP
 
 #include "device/load_store_matrix_sync.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -39,6 +40,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     public:
         LoadStoreMatrixSyncKernel()          = default;
@@ -54,8 +58,10 @@ namespace rocwmma
 
             // Initialize data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
             // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
@@ -79,6 +85,43 @@ namespace rocwmma
                                                              Base::mM,
                                                              Base::mN,
                                                              errorTolerance);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
 
         virtual typename Base::KernelFunc kernelImpl() const = 0;

--- a/test/unit/detail/map_block_to_matrix.hpp
+++ b/test/unit/detail/map_block_to_matrix.hpp
@@ -54,9 +54,10 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
-            
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
             dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
@@ -66,7 +67,7 @@ namespace rocwmma
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            const int64_t sizeD        = Base::mM * Base::mN;
+            const int64_t sizeD = Base::mM * Base::mN;
 
             // Cache current kernel result from device
             dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);

--- a/test/unit/detail/map_block_to_matrix_override.hpp
+++ b/test/unit/detail/map_block_to_matrix_override.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_MAP_BLOCK_TO_MATRIX_OVERRIDE_HPP
 
 #include "device/map_block_to_matrix_override.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -38,6 +39,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     protected:
         enum : int32_t
@@ -157,6 +161,43 @@ namespace rocwmma
                                                              Base::mM,
                                                              Base::mN,
                                                              errorTolerance);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
     };
 

--- a/test/unit/detail/map_matrix_to_data.hpp
+++ b/test/unit/detail/map_matrix_to_data.hpp
@@ -54,9 +54,11 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
-            
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
+
             // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
             dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);

--- a/test/unit/detail/map_matrix_to_data_override.hpp
+++ b/test/unit/detail/map_matrix_to_data_override.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_MAP_MATRIX_TO_DATA_OVERRIDE_HPP
 
 #include "device/map_matrix_to_data_override.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -38,6 +39,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     protected:
         enum : int32_t
@@ -158,6 +162,43 @@ namespace rocwmma
                                                              Base::mM,
                                                              Base::mN,
                                                              errorTolerance);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
     };
 

--- a/test/unit/detail/map_thread_to_matrix.hpp
+++ b/test/unit/detail/map_thread_to_matrix.hpp
@@ -54,8 +54,10 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
             dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);

--- a/test/unit/detail/map_wave_to_matrix.hpp
+++ b/test/unit/detail/map_wave_to_matrix.hpp
@@ -54,8 +54,10 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
             dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);

--- a/test/unit/detail/row_layout.hpp
+++ b/test/unit/detail/row_layout.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_ROW_LAYOUT_HPP
 
 #include "device/row_layout.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -39,6 +40,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     public:
         RowLayoutKernel()        = default;
@@ -54,8 +58,10 @@ namespace rocwmma
 
             // Initialize matrix data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
             dataInstance->copyData(dataInstance->deviceOut(), dataInstance->hostOut(), sizeD);
@@ -65,7 +71,7 @@ namespace rocwmma
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            const int64_t sizeD        = Base::mM * Base::mN;
+            const int64_t sizeD = Base::mM * Base::mN;
 
             // Cache current kernel result from device
             dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
@@ -78,6 +84,43 @@ namespace rocwmma
                                                              Base::mM,
                                                              Base::mN,
                                                              errorTolerance);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
 
         typename Base::KernelFunc kernelImpl() const final

--- a/test/unit/detail/rownt_layout.hpp
+++ b/test/unit/detail/rownt_layout.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_ROWNT_LAYOUT_HPP
 
 #include "device/rownt_layout.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -39,6 +40,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     public:
         RowNTLayoutKernel()        = default;
@@ -54,8 +58,10 @@ namespace rocwmma
 
             // Initialize data on host
             MatrixUtil<Layout>::fill(dataInstance->hostIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fill(
-                dataInstance->hostOut().get(), Base::mM, Base::mN, std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fill(dataInstance->hostOut().get(),
+                                     Base::mM,
+                                     Base::mN,
+                                     std::numeric_limits<DataT>::signaling_NaN());
 
             // Copy init data to device
             dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);
@@ -66,7 +72,7 @@ namespace rocwmma
         {
             auto& dataInstance = Base::DataStorage::instance();
 
-            const int64_t sizeD        = Base::mM * Base::mN;
+            const int64_t sizeD = Base::mM * Base::mN;
 
             // Cache current kernel result from device
             dataInstance->copyData(dataInstance->hostOut(), dataInstance->deviceOut(), sizeD);
@@ -79,6 +85,43 @@ namespace rocwmma
                                                              Base::mM,
                                                              Base::mN,
                                                              errorTolerance);
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
 
         typename Base::KernelFunc kernelImpl() const final

--- a/test/unit/detail/store_contamination.hpp
+++ b/test/unit/detail/store_contamination.hpp
@@ -28,6 +28,7 @@
 #define ROCWMMA_DETAIL_STORE_CONTAMINATION_HPP
 
 #include "device/store_contamination.hpp"
+#include "helper_macros.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
@@ -39,6 +40,9 @@ namespace rocwmma
     {
     private:
         using Base = UnitKernelBase<BlockM, BlockN, DataT, Layout>;
+
+        template <uint32_t WaveSize, uint32_t ArchId>
+        using TestGuard = FragSize_guard<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
 
     public:
         StoreContaminationKernel()          = default;
@@ -102,6 +106,43 @@ namespace rocwmma
 
             // All padding must be markers
             Base::mValidationResult = (result == (paddedElements - Base::mM * Base::mN));
+        }
+
+        bool checkQuirks() const final
+        {
+            auto waveSize   = Base::DeviceInfo::instance()->warpSize();
+            auto deviceArch = Base::DeviceInfo::instance()->getGcnArch();
+
+            // The test guard for this class requires 2 values at runtime.
+            auto dispatchGuard = [waveSize, deviceArch]() {
+                bool dispatchResult = false;
+
+#define CASE_IMPL_ASSIGN2(WAVE_SIZE, ARCH_ID) \
+    dispatchResult = TestGuard<WAVE_SIZE, ARCH_ID>::enable();
+
+#define SWITCH_BODY_WAVE_SIZE(ARCH_ID) \
+    ROCWMMA_SWITCH_BODY2_ARG2(         \
+        waveSize, CASE_IMPL_ASSIGN2, HipDevice::Wave32, HipDevice::Wave64, ARCH_ID)
+
+#define DISPATCH_GUARD_BODY                          \
+    ROCWMMA_SWITCH_BODY5_ARG1(deviceArch,            \
+                              SWITCH_BODY_WAVE_SIZE, \
+                              HipDevice::GFX908,     \
+                              HipDevice::GFX90A,     \
+                              HipDevice::GFX1100,    \
+                              HipDevice::GFX1101,    \
+                              HipDevice::GFX1102)
+
+                DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN2
+#undef SWITCH_BODY_WAVE_SIZE
+#undef DISPATCH_GUARD_BODY
+
+                return dispatchResult;
+            };
+
+            return Base::checkQuirks() && dispatchGuard();
         }
 
         typename Base::KernelFunc kernelImpl() const = 0;

--- a/test/unit/device/col_layout.hpp
+++ b/test/unit/device/col_layout.hpp
@@ -27,14 +27,24 @@
 #ifndef ROCWMMA_DEVICE_COL_LAYOUT_HPP
 #define ROCWMMA_DEVICE_COL_LAYOUT_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/io_traits.hpp>
 #include <rocwmma/internal/layout.hpp>
 #include <rocwmma/internal/mapping_util.hpp>
 
 namespace rocwmma
 {
-
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename LayoutP>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void ColLayout(uint32_t     m,
                               uint32_t     n,
                               DataT const* in,
@@ -46,12 +56,12 @@ namespace rocwmma
         enum : uint32_t
         {
             MaxVectorWidth = detail::VecWidthTraits<BlockM, BlockN, DataT>::MaxVectorWidth,
-            VectorWidth    = std::is_same<LayoutP, row_major>::value ? MaxVectorWidth : 1
+            VectorWidth    = std::is_same<DataLayout, row_major>::value ? MaxVectorWidth : 1
         };
 
         using IOTraits = IOTraits<BlockM, BlockN, DataT, VectorWidth>;
-        using LayoutT  = MatrixLayout::Col<BlockM, BlockN, DataT, LayoutP, VectorWidth>;
-        using Mapping  = MappingUtil<BlockM, BlockN, DataT, LayoutP>;
+        using LayoutT  = MatrixLayout::Col<BlockM, BlockN, DataT, DataLayout, VectorWidth>;
+        using Mapping  = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         auto baseOffset  = LayoutT::baseOffset();
         auto iocount     = IOTraits::IOCount;
@@ -59,8 +69,8 @@ namespace rocwmma
 
         enum : uint32_t
         {
-            MajorIndex = std::is_same<LayoutP, row_major>::value ? 0 : 1,
-            MinorIndex = std::is_same<LayoutP, row_major>::value ? 1 : 0
+            MajorIndex = std::is_same<DataLayout, row_major>::value ? 0 : 1,
+            MinorIndex = std::is_same<DataLayout, row_major>::value ? 1 : 0
         };
 
         for(uint32_t i = 0; i < iocount; ++i)
@@ -75,6 +85,26 @@ namespace rocwmma
         }
     }
 
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void ColLayout(uint32_t     m,
+                              uint32_t     n,
+                              DataT const* in,
+                              DataT*       out,
+                              uint32_t     ld,
+                              DataT        param1,
+                              DataT        param2)
+    {
+    }
 } // namespace rocwmma
 
 #endif // ROCWMMA_DEVICE_COL_LAYOUT_HPP

--- a/test/unit/device/colnt_layout.hpp
+++ b/test/unit/device/colnt_layout.hpp
@@ -27,14 +27,24 @@
 #ifndef ROCWMMA_DEVICE_COLNT_LAYOUT_HPP
 #define ROCWMMA_DEVICE_COLNT_LAYOUT_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/io_traits.hpp>
 #include <rocwmma/internal/layout.hpp>
 #include <rocwmma/internal/mapping_util.hpp>
 
 namespace rocwmma
 {
-
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename LayoutP>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void ColNTLayout(uint32_t     m,
                                 uint32_t     n,
                                 DataT const* in,
@@ -46,13 +56,13 @@ namespace rocwmma
         enum : uint32_t
         {
             MaxVectorWidth = detail::VecWidthTraits<BlockM, BlockN, DataT>::MaxVectorWidth,
-            VectorWidth    = std::is_same<LayoutP, row_major>::value ? MaxVectorWidth : 1
+            VectorWidth    = std::is_same<DataLayout, row_major>::value ? MaxVectorWidth : 1
         };
 
         using IOTraits = IOTraits<BlockM, BlockN, DataT, VectorWidth>;
         using LayoutT
-            = MatrixLayout::ColNT<BlockM, BlockN, DataT, LayoutP, VectorWidth, MaxVectorWidth>;
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, LayoutP>;
+            = MatrixLayout::ColNT<BlockM, BlockN, DataT, DataLayout, VectorWidth, MaxVectorWidth>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         auto baseOffset  = LayoutT::baseOffset();
         auto iocount     = IOTraits::IOCount;
@@ -60,8 +70,8 @@ namespace rocwmma
 
         enum : uint32_t
         {
-            MajorIndex = std::is_same<LayoutP, row_major>::value ? 0 : 1,
-            MinorIndex = std::is_same<LayoutP, row_major>::value ? 1 : 0
+            MajorIndex = std::is_same<DataLayout, row_major>::value ? 0 : 1,
+            MinorIndex = std::is_same<DataLayout, row_major>::value ? 1 : 0
         };
 
         for(uint32_t i = 0; i < iocount; ++i)
@@ -76,6 +86,26 @@ namespace rocwmma
         }
     }
 
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void ColNTLayout(uint32_t     m,
+                                uint32_t     n,
+                                DataT const* in,
+                                DataT*       out,
+                                uint32_t     ld,
+                                DataT        param1,
+                                DataT        param2)
+    {
+    }
 } // namespace rocwmma
 
 #endif // ROCWMMA_DEVICE_COLNT_LAYOUT_HPP

--- a/test/unit/device/fill_fragment.hpp
+++ b/test/unit/device/fill_fragment.hpp
@@ -27,12 +27,24 @@
 #ifndef ROCWMMA_DEVICE_FILL_FRAGMENT_HPP
 #define ROCWMMA_DEVICE_FILL_FRAGMENT_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/mapping_util.hpp>
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void fillFragmentA(uint32_t     m,
                                   uint32_t     n,
                                   DataT const* in,
@@ -41,10 +53,10 @@ namespace rocwmma
                                   DataT        param1,
                                   DataT        param2)
     {
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         // Create frag and fill
-        auto frag = fragment<matrix_a, BlockM, 1, BlockN, DataT, Layout>();
+        auto frag = fragment<matrix_a, BlockM, 1, BlockN, DataT, DataLayout>();
 
         fill_fragment(frag, param1);
 
@@ -53,7 +65,38 @@ namespace rocwmma
         store_matrix_sync(offset, frag, ld);
     }
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void fillFragmentA(uint32_t     m,
+                                  uint32_t     n,
+                                  DataT const* in,
+                                  DataT*       out,
+                                  uint32_t     ld,
+                                  DataT        param1,
+                                  DataT        param2)
+    {
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void fillFragmentB(uint32_t     m,
                                   uint32_t     n,
                                   DataT const* in,
@@ -62,10 +105,10 @@ namespace rocwmma
                                   DataT        param1,
                                   DataT        param2)
     {
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         // Create frag and fill
-        auto frag = fragment<matrix_b, 1, BlockN, BlockM, DataT, Layout>();
+        auto frag = fragment<matrix_b, 1, BlockN, BlockM, DataT, DataLayout>();
 
         fill_fragment(frag, param1);
 
@@ -74,7 +117,38 @@ namespace rocwmma
         store_matrix_sync(offset, frag, ld);
     }
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void fillFragmentB(uint32_t     m,
+                                  uint32_t     n,
+                                  DataT const* in,
+                                  DataT*       out,
+                                  uint32_t     ld,
+                                  DataT        param1,
+                                  DataT        param2)
+    {
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void fillFragmentAcc(uint32_t     m,
                                     uint32_t     n,
                                     DataT const* in,
@@ -83,16 +157,37 @@ namespace rocwmma
                                     DataT        param1,
                                     DataT        param2)
     {
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         // Create frag and fill
-        auto frag = fragment<accumulator, BlockM, BlockN, 1, DataT, Layout>();
+        auto frag = fragment<accumulator, BlockM, BlockN, 1, DataT, DataLayout>();
 
         fill_fragment(frag, param1);
 
         // Map and store
         auto* offset = Mapping::dataCoord(out, ld);
         store_matrix_sync(offset, frag, ld);
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void fillFragmentAcc(uint32_t     m,
+                                    uint32_t     n,
+                                    DataT const* in,
+                                    DataT*       out,
+                                    uint32_t     ld,
+                                    DataT        param1,
+                                    DataT        param2)
+    {
     }
 
 } // namespace rocwmma

--- a/test/unit/device/load_store_matrix_coop_sync.hpp
+++ b/test/unit/device/load_store_matrix_coop_sync.hpp
@@ -31,10 +31,22 @@
 #include <rocwmma/rocwmma.hpp>
 #include <rocwmma/rocwmma_coop.hpp>
 
+#include "unit_test_traits.hpp"
+
 namespace rocwmma
 {
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncA(uint32_t     m,
                                                                     uint32_t     n,
                                                                     DataT const* in,
@@ -48,9 +60,9 @@ namespace rocwmma
         // BlockM -> BlockM
         // <Dummy> -> BlockN
         // BlockN -> BlockK
-        auto frag = fragment<matrix_a, BlockM, 1, BlockN, DataT, Layout>();
+        auto frag = fragment<matrix_a, BlockM, 1, BlockN, DataT, DataLayout>();
 
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         auto workgroupDim      = Mapping::workgroupDim();
         auto waveCoord         = Mapping::waveCoord();
@@ -100,7 +112,38 @@ namespace rocwmma
         }
     }
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncA(uint32_t     m,
+                                                                    uint32_t     n,
+                                                                    DataT const* in,
+                                                                    DataT*       out,
+                                                                    uint32_t     ld,
+                                                                    DataT        param1,
+                                                                    DataT        param2)
+    {
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncB(uint32_t     m,
                                                                     uint32_t     n,
                                                                     DataT const* in,
@@ -114,9 +157,9 @@ namespace rocwmma
         // <Dummy> -> BlockM
         // BlockN -> BlockN
         // BlockM -> BlockK
-        auto frag = fragment<matrix_b, 1, BlockN, BlockM, DataT, Layout>();
+        auto frag = fragment<matrix_b, 1, BlockN, BlockM, DataT, DataLayout>();
 
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         auto workgroupDim      = Mapping::workgroupDim();
         auto waveCoord         = Mapping::waveCoord();
@@ -166,7 +209,38 @@ namespace rocwmma
         }
     }
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncB(uint32_t     m,
+                                                                    uint32_t     n,
+                                                                    DataT const* in,
+                                                                    DataT*       out,
+                                                                    uint32_t     ld,
+                                                                    DataT        param1,
+                                                                    DataT        param2)
+    {
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncAcc(uint32_t     m,
                                                                       uint32_t     n,
                                                                       DataT const* in,
@@ -180,9 +254,9 @@ namespace rocwmma
         // BlockM -> BlockM
         // BlockN -> BlockN
         // <Dummy> -> BlockK
-        auto frag = fragment<accumulator, BlockM, BlockN, 1, DataT, Layout>();
+        auto frag = fragment<accumulator, BlockM, BlockN, 1, DataT, DataLayout>();
 
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         auto workgroupDim      = Mapping::workgroupDim();
         auto waveCoord         = Mapping::waveCoord();
@@ -229,6 +303,27 @@ namespace rocwmma
                 }
             }
         }
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncAcc(uint32_t     m,
+                                                                      uint32_t     n,
+                                                                      DataT const* in,
+                                                                      DataT*       out,
+                                                                      uint32_t     ld,
+                                                                      DataT        param1,
+                                                                      DataT        param2)
+    {
     }
 
 } // namespace rocwmma

--- a/test/unit/device/map_block_to_matrix.hpp
+++ b/test/unit/device/map_block_to_matrix.hpp
@@ -27,13 +27,13 @@
 #ifndef ROCWMMA_DEVICE_MAP_BLOCK_TO_MATRIX_HPP
 #define ROCWMMA_DEVICE_MAP_BLOCK_TO_MATRIX_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/mapping_util.hpp>
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
-
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename DataLayout>
     __global__ void MapBlockToMatrix(uint32_t     m,
                                      uint32_t     n,
                                      DataT const* in,
@@ -42,15 +42,15 @@ namespace rocwmma
                                      DataT        param1,
                                      DataT        param2)
     {
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
         auto aCoord   = Mapping::blockCoord();
 
         enum : uint32_t
         {
-            MajorIndex = std::is_same<Layout, row_major>::value ? 0 : 1,
-            MinorIndex = std::is_same<Layout, row_major>::value ? 1 : 0,
-            ldmajor    = std::is_same<Layout, row_major>::value ? BlockM : BlockN,
-            ldminor    = std::is_same<Layout, row_major>::value ? BlockN : BlockM
+            MajorIndex = std::is_same<DataLayout, row_major>::value ? 0 : 1,
+            MinorIndex = std::is_same<DataLayout, row_major>::value ? 1 : 0,
+            ldmajor    = std::is_same<DataLayout, row_major>::value ? BlockM : BlockN,
+            ldminor    = std::is_same<DataLayout, row_major>::value ? BlockN : BlockM
         };
 
         auto majCoord = get<MajorIndex>(aCoord) * ldmajor;

--- a/test/unit/device/map_block_to_matrix_override.hpp
+++ b/test/unit/device/map_block_to_matrix_override.hpp
@@ -27,12 +27,22 @@
 #ifndef ROCWMMA_DEVICE_MAP_BLOCK_TO_MATRIX_OVERRIDE_HPP
 #define ROCWMMA_DEVICE_MAP_BLOCK_TO_MATRIX_OVERRIDE_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
-
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename DataLayout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void MapBlockToMatrixOverrideM(uint32_t     m,
                                               uint32_t     n,
                                               DataT const* in,
@@ -41,7 +51,7 @@ namespace rocwmma
                                               DataT        param1,
                                               DataT        param2)
     {
-        using Frag = fragment<accumulator, BlockM, BlockN, 1, DataT, DataLayout>;
+        using Frag    = fragment<accumulator, BlockM, BlockN, 1, DataT, DataLayout>;
         using Mapping = typename Frag::IOConfig::MappingUtil;
 
         // Override read M coord
@@ -54,7 +64,38 @@ namespace rocwmma
         store_matrix_sync(Mapping::dataCoord(out, writeCoord, ld), f, ld);
     }
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename DataLayout>
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void MapBlockToMatrixOverrideM(uint32_t     m,
+                                              uint32_t     n,
+                                              DataT const* in,
+                                              DataT*       out,
+                                              uint32_t     ld,
+                                              DataT        param1,
+                                              DataT        param2)
+    {
+    }
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  FragSize_guard<BlockM,
+                                 BlockN,
+                                 DataT,
+                                 DataLayout,
+                                 Constants::AMDGCN_WAVE_SIZE,
+                                 Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
     __global__ void MapBlockToMatrixOverrideN(uint32_t     m,
                                               uint32_t     n,
                                               DataT const* in,
@@ -63,7 +104,7 @@ namespace rocwmma
                                               DataT        param1,
                                               DataT        param2)
     {
-        using Frag = fragment<accumulator, BlockM, BlockN, 1, DataT, DataLayout>;
+        using Frag    = fragment<accumulator, BlockM, BlockN, 1, DataT, DataLayout>;
         using Mapping = typename Frag::IOConfig::MappingUtil;
 
         // Override read N coord
@@ -76,6 +117,26 @@ namespace rocwmma
         store_matrix_sync(Mapping::dataCoord(out, writeCoord, ld), f, ld);
     }
 
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename DataLayout,
+              typename std::enable_if_t<
+                  !FragSize_guard<BlockM,
+                                  BlockN,
+                                  DataT,
+                                  DataLayout,
+                                  Constants::AMDGCN_WAVE_SIZE,
+                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
+    __global__ void MapBlockToMatrixOverrideN(uint32_t     m,
+                                              uint32_t     n,
+                                              DataT const* in,
+                                              DataT*       out,
+                                              uint32_t     ld,
+                                              DataT        param1,
+                                              DataT        param2)
+    {
+    }
 } // namespace rocwmma
 
 #endif // ROCWMMA_DEVICE_MAP_BLOCK_TO_MATRIX_OVERRIDE_HPP

--- a/test/unit/device/map_matrix_to_data.hpp
+++ b/test/unit/device/map_matrix_to_data.hpp
@@ -27,13 +27,13 @@
 #ifndef ROCWMMA_DEVICE_MAP_MATRIX_TO_DATA_HPP
 #define ROCWMMA_DEVICE_MAP_MATRIX_TO_DATA_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/mapping_util.hpp>
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
-
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename DataLayout>
     __global__ void MapMatrixToData(uint32_t     m,
                                     uint32_t     n,
                                     DataT const* in,
@@ -42,15 +42,15 @@ namespace rocwmma
                                     DataT        param1,
                                     DataT        param2)
     {
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
         auto aCoord   = Mapping::matrixCoord();
 
         enum : uint32_t
         {
-            MajorIndex = std::is_same<Layout, row_major>::value ? 0 : 1,
-            MinorIndex = std::is_same<Layout, row_major>::value ? 1 : 0,
-            ldmajor    = std::is_same<Layout, row_major>::value ? BlockM : BlockN,
-            ldminor    = std::is_same<Layout, row_major>::value ? BlockN : BlockM
+            MajorIndex = std::is_same<DataLayout, row_major>::value ? 0 : 1,
+            MinorIndex = std::is_same<DataLayout, row_major>::value ? 1 : 0,
+            ldmajor    = std::is_same<DataLayout, row_major>::value ? BlockM : BlockN,
+            ldminor    = std::is_same<DataLayout, row_major>::value ? BlockN : BlockM
         };
 
         auto majCoord = get<MajorIndex>(aCoord);

--- a/test/unit/device/map_thread_to_matrix.hpp
+++ b/test/unit/device/map_thread_to_matrix.hpp
@@ -27,13 +27,13 @@
 #ifndef ROCWMMA_DEVICE_MAP_THREAD_TO_MATRIX_HPP
 #define ROCWMMA_DEVICE_MAP_THREAD_TO_MATRIX_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/mapping_util.hpp>
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
-
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename DataLayout>
     __global__ void MapThreadToMatrix(uint32_t     m,
                                       uint32_t     n,
                                       DataT const* in,
@@ -42,23 +42,23 @@ namespace rocwmma
                                       DataT        param1,
                                       DataT        param2)
     {
-        using Mapping = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
         enum : uint32_t
         {
-            MajorIndex = std::is_same<Layout, row_major>::value ? 0 : 1,
-            MinorIndex = std::is_same<Layout, row_major>::value ? 1 : 0,
-            ldmajor    = std::is_same<Layout, row_major>::value ? BlockM : BlockN,
-            ldminor    = std::is_same<Layout, row_major>::value ? BlockN : BlockM
+            MajorIndex = std::is_same<DataLayout, row_major>::value ? 0 : 1,
+            MinorIndex = std::is_same<DataLayout, row_major>::value ? 1 : 0,
+            ldmajor    = std::is_same<DataLayout, row_major>::value ? BlockM : BlockN,
+            ldminor    = std::is_same<DataLayout, row_major>::value ? BlockN : BlockM
         };
 
         auto majCoord
-            = (std::is_same<Layout, row_major>::value
+            = (std::is_same<DataLayout, row_major>::value
                    ? ((threadIdx.x + blockDim.x * blockIdx.x) / Constants::AMDGCN_WAVE_SIZE)
                    : (threadIdx.y + blockDim.y * blockIdx.y))
               * ldmajor;
         auto minCoord
-            = (std::is_same<Layout, row_major>::value
+            = (std::is_same<DataLayout, row_major>::value
                    ? (threadIdx.y + blockDim.y * blockIdx.y)
                    : ((threadIdx.x + blockDim.x * blockIdx.x) / Constants::AMDGCN_WAVE_SIZE))
               * ldminor;

--- a/test/unit/device/map_wave_to_matrix.hpp
+++ b/test/unit/device/map_wave_to_matrix.hpp
@@ -27,13 +27,14 @@
 #ifndef ROCWMMA_DEVICE_MAP_WAVE_TO_MATRIX_HPP
 #define ROCWMMA_DEVICE_MAP_WAVE_TO_MATRIX_HPP
 
+#include "unit_test_traits.hpp"
 #include <rocwmma/internal/mapping_util.hpp>
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
 
-    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
+    template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename DataLayout>
     __global__ void MapWaveToMatrix(uint32_t     m,
                                     uint32_t     n,
                                     DataT const* in,
@@ -42,17 +43,17 @@ namespace rocwmma
                                     DataT        param1,
                                     DataT        param2)
     {
-        using Mapping     = MappingUtil<BlockM, BlockN, DataT, Layout>;
+        using Mapping     = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
         auto aCoord       = Mapping::waveCoord();
         auto aCoord_wg    = Mapping::WaveSpace::workgroupCoord();
         auto aCoord_wgdim = Mapping::WaveSpace::workgroupDim();
 
         enum : uint32_t
         {
-            MajorIndex = std::is_same<Layout, row_major>::value ? 0 : 1,
-            MinorIndex = std::is_same<Layout, row_major>::value ? 1 : 0,
-            ldmajor    = std::is_same<Layout, row_major>::value ? BlockM : BlockN,
-            ldminor    = std::is_same<Layout, row_major>::value ? BlockN : BlockM
+            MajorIndex = std::is_same<DataLayout, row_major>::value ? 0 : 1,
+            MinorIndex = std::is_same<DataLayout, row_major>::value ? 1 : 0,
+            ldmajor    = std::is_same<DataLayout, row_major>::value ? BlockM : BlockN,
+            ldminor    = std::is_same<DataLayout, row_major>::value ? BlockN : BlockM
         };
 
         auto majCoord

--- a/test/unit/test/unit_test_params.hpp
+++ b/test/unit/test/unit_test_params.hpp
@@ -175,10 +175,6 @@ namespace rocwmma
                  {3072, 3072},
                  {3584, 3584},
                  {4096, 4096},
-                 {5120, 5120},
-                 {6144, 6144},
-                 {7168, 7168},
-                 {8192, 8192}
 #endif // ROCWMMA_EXTENDED_TESTS
         };
             // clang-format on

--- a/test/unit/unit_test_traits.hpp
+++ b/test/unit/unit_test_traits.hpp
@@ -99,7 +99,7 @@ namespace rocwmma
         {
             // Cost for a full tile, unpacked data
             CostTest = ((uint32_t)TestTraits::Cost::UnpackedTile <= 256u),
-            Enable   = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64)
+            Enable   = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && CostTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/unit/unit_test_traits.hpp
+++ b/test/unit/unit_test_traits.hpp
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_UNIT_TEST_TRAITS_HPP
+#define ROCWMMA_UNIT_TEST_TRAITS_HPP
+
+// The testing interface instantiates fp64 typed tests for all
+// target devices. MI-100 mfma needs to be instantiated at compile time,
+// but it doesn't do anything except provide a deprecation warning (e.g. not supported).
+// A run-time check will abort the MI-100 fp64 tests anyway.
+// Silence this warning for MmaSyncTests, as test coverage is needed
+// for fp64 on all other targets which succeed MI-100.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include <rocwmma/rocwmma.hpp>
+#pragma GCC diagnostic pop
+
+namespace rocwmma
+{
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename Layout,
+              uint32_t WaveSize,
+              uint32_t ArchId>
+    struct UnitTestTraits
+    {
+        // Size properties of gemm tiles
+        enum struct Sizes : uint32_t
+        {
+            TileX    = BlockM,
+            TileY    = BlockN,
+            TileSize = TileX * TileY * sizeof(DataT),
+        };
+
+        // Tile costs
+        enum struct Cost : uint32_t
+        {
+            Granularity = 16u,
+            DWord       = 4u,
+
+            PackedTile
+            = ceilDiv((uint32_t)Sizes::TileSize, Granularity* WaveSize* DWord) * Granularity,
+            UnpackedTile = PackedTile * detail::PackTraits<DataT>::PackRatio,
+        };
+
+        // Architecture we are testing
+        enum Arch : bool
+        {
+            IsWave32 = (WaveSize == Constants::AMDGCN_WAVE_SIZE_32),
+            IsWave64 = (WaveSize == Constants::AMDGCN_WAVE_SIZE_64),
+
+            IsGfx908  = (ArchId == Constants::AMDGCN_ARCH_ID_GFX908),
+            IsGfx90A  = (ArchId == Constants::AMDGCN_ARCH_ID_GFX90A),
+            IsGfx1100 = (ArchId == Constants::AMDGCN_ARCH_ID_GFX1100),
+            IsGfx1101 = (ArchId == Constants::AMDGCN_ARCH_ID_GFX1101),
+            IsGfx1102 = (ArchId == Constants::AMDGCN_ARCH_ID_GFX1102),
+
+            IsGfx9  = IsGfx908 || IsGfx90A,
+            IsGfx11 = IsGfx1100 || IsGfx1101 || IsGfx1102,
+        };
+    };
+
+    template <uint32_t BlockM,
+              uint32_t BlockN,
+              typename DataT,
+              typename Layout,
+              uint32_t WaveSize,
+              uint32_t ArchId>
+    struct FragSize_guard
+    {
+        using TestTraits = UnitTestTraits<BlockM, BlockN, DataT, Layout, WaveSize, ArchId>;
+
+    private:
+        enum struct Gfx9Predicates : bool
+        {
+            // Cost for a full tile, unpacked data
+            CostTest = ((uint32_t)TestTraits::Cost::UnpackedTile <= 256u),
+            Enable   = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64)
+        };
+
+        enum struct Gfx11Predicates : bool
+        {
+            // Cost for a full tile, unpacked data
+            CostTest = ((uint32_t)TestTraits::Cost::UnpackedTile <= 256u),
+            Enable   = ((bool)TestTraits::IsGfx11 && (bool)TestTraits::IsWave32 && CostTest)
+        };
+
+    public:
+        constexpr static bool enable()
+        {
+            return ((bool)Gfx9Predicates::Enable || (bool)Gfx11Predicates::Enable);
+        }
+    };
+
+} // namespace rocWMMA
+
+#endif // ROCWMMA_UNIT_TEST_TRAITS_HPP


### PR DESCRIPTION
- Add unit test build / run guards based on cost estimates
- Enforce guards for gfx9 and gfx11
- Reduce unit test load to max 4k x 4k problem sizes
- Should now properly support extended tests

- @mkarunan implementation