### PR TITLE
Fix ext vector test

### DIFF
--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/test/block/CMakeLists.txt
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/test/block/CMakeLists.txt
@@ -69,8 +69,7 @@ if(ROCWMMA_BUILD_EXTENDED_TESTS)
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_nn_4x8.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_nn_8x1.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_nn_8x2.cpp
-                                ${CMAKE_CURRENT_SOURCE_DIR}/16x16_nn_8x4.cpp
-                                # TODO: MI-100 Compile restriction
+                                #${CMAKE_CURRENT_SOURCE_DIR}/16x16_nn_8x4.cpp
                                 #${CMAKE_CURRENT_SOURCE_DIR}/16x16_nn_8x8.cpp
 
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_nt_1x2.cpp
@@ -112,7 +111,7 @@ if(ROCWMMA_BUILD_EXTENDED_TESTS)
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_tt_4x8.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_tt_8x1.cpp
                                 ${CMAKE_CURRENT_SOURCE_DIR}/16x16_tt_8x2.cpp
-                                ${CMAKE_CURRENT_SOURCE_DIR}/16x16_tt_8x4.cpp
+                                #${CMAKE_CURRENT_SOURCE_DIR}/16x16_tt_8x4.cpp
                                 #${CMAKE_CURRENT_SOURCE_DIR}/16x16_tt_8x8.cpp
 
                                 ${CMAKE_CURRENT_SOURCE_DIR}/32x32_nn_1x2.cpp

--- a/test/unit/device/load_store_matrix_coop_sync.hpp
+++ b/test/unit/device/load_store_matrix_coop_sync.hpp
@@ -47,13 +47,13 @@ namespace rocwmma
                                  DataLayout,
                                  Constants::AMDGCN_WAVE_SIZE,
                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncA(uint32_t     m,
-                                                                    uint32_t     n,
-                                                                    DataT const* in,
-                                                                    DataT*       out,
-                                                                    uint32_t     ld,
-                                                                    DataT        param1,
-                                                                    DataT        param2)
+    __global__ void LoadStoreMatrixCoopSyncA(uint32_t     m,
+                                             uint32_t     n,
+                                             DataT const* in,
+                                             DataT*       out,
+                                             uint32_t     ld,
+                                             DataT        param1,
+                                             DataT        param2)
     {
         // Mapping:
         // Incoming -> Matrix A (ColNT)
@@ -123,13 +123,13 @@ namespace rocwmma
                                   DataLayout,
                                   Constants::AMDGCN_WAVE_SIZE,
                                   Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncA(uint32_t     m,
-                                                                    uint32_t     n,
-                                                                    DataT const* in,
-                                                                    DataT*       out,
-                                                                    uint32_t     ld,
-                                                                    DataT        param1,
-                                                                    DataT        param2)
+    __global__ void LoadStoreMatrixCoopSyncA(uint32_t     m,
+                                             uint32_t     n,
+                                             DataT const* in,
+                                             DataT*       out,
+                                             uint32_t     ld,
+                                             DataT        param1,
+                                             DataT        param2)
     {
     }
 
@@ -144,13 +144,13 @@ namespace rocwmma
                                  DataLayout,
                                  Constants::AMDGCN_WAVE_SIZE,
                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncB(uint32_t     m,
-                                                                    uint32_t     n,
-                                                                    DataT const* in,
-                                                                    DataT*       out,
-                                                                    uint32_t     ld,
-                                                                    DataT        param1,
-                                                                    DataT        param2)
+    __global__ void LoadStoreMatrixCoopSyncB(uint32_t     m,
+                                             uint32_t     n,
+                                             DataT const* in,
+                                             DataT*       out,
+                                             uint32_t     ld,
+                                             DataT        param1,
+                                             DataT        param2)
     {
         // Mapping:
         // Incoming -> Matrix B (RowNT)
@@ -220,13 +220,13 @@ namespace rocwmma
                                   DataLayout,
                                   Constants::AMDGCN_WAVE_SIZE,
                                   Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncB(uint32_t     m,
-                                                                    uint32_t     n,
-                                                                    DataT const* in,
-                                                                    DataT*       out,
-                                                                    uint32_t     ld,
-                                                                    DataT        param1,
-                                                                    DataT        param2)
+    __global__ void LoadStoreMatrixCoopSyncB(uint32_t     m,
+                                             uint32_t     n,
+                                             DataT const* in,
+                                             DataT*       out,
+                                             uint32_t     ld,
+                                             DataT        param1,
+                                             DataT        param2)
     {
     }
 
@@ -241,13 +241,13 @@ namespace rocwmma
                                  DataLayout,
                                  Constants::AMDGCN_WAVE_SIZE,
                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncAcc(uint32_t     m,
-                                                                      uint32_t     n,
-                                                                      DataT const* in,
-                                                                      DataT*       out,
-                                                                      uint32_t     ld,
-                                                                      DataT        param1,
-                                                                      DataT        param2)
+    __global__ void LoadStoreMatrixCoopSyncAcc(uint32_t     m,
+                                               uint32_t     n,
+                                               DataT const* in,
+                                               DataT*       out,
+                                               uint32_t     ld,
+                                               DataT        param1,
+                                               DataT        param2)
     {
         // Mapping:
         // Incoming -> Matrix C (Row4T)
@@ -316,13 +316,13 @@ namespace rocwmma
                                   DataLayout,
                                   Constants::AMDGCN_WAVE_SIZE,
                                   Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixCoopSyncAcc(uint32_t     m,
-                                                                      uint32_t     n,
-                                                                      DataT const* in,
-                                                                      DataT*       out,
-                                                                      uint32_t     ld,
-                                                                      DataT        param1,
-                                                                      DataT        param2)
+    __global__ void LoadStoreMatrixCoopSyncAcc(uint32_t     m,
+                                               uint32_t     n,
+                                               DataT const* in,
+                                               DataT*       out,
+                                               uint32_t     ld,
+                                               DataT        param1,
+                                               DataT        param2)
     {
     }
 

--- a/test/unit/device/load_store_matrix_sync.hpp
+++ b/test/unit/device/load_store_matrix_sync.hpp
@@ -46,13 +46,13 @@ namespace rocwmma
                                  DataLayout,
                                  Constants::AMDGCN_WAVE_SIZE,
                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixSyncA(uint32_t     m,
-                                                                uint32_t     n,
-                                                                DataT const* in,
-                                                                DataT*       out,
-                                                                uint32_t     ld,
-                                                                DataT        param1,
-                                                                DataT        param2)
+    __global__ void LoadStoreMatrixSyncA(uint32_t     m,
+                                         uint32_t     n,
+                                         DataT const* in,
+                                         DataT*       out,
+                                         uint32_t     ld,
+                                         DataT        param1,
+                                         DataT        param2)
     {
         using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
@@ -81,13 +81,13 @@ namespace rocwmma
                                   DataLayout,
                                   Constants::AMDGCN_WAVE_SIZE,
                                   Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixSyncA(uint32_t     m,
-                                                                uint32_t     n,
-                                                                DataT const* in,
-                                                                DataT*       out,
-                                                                uint32_t     ld,
-                                                                DataT        param1,
-                                                                DataT        param2)
+    __global__ void LoadStoreMatrixSyncA(uint32_t     m,
+                                         uint32_t     n,
+                                         DataT const* in,
+                                         DataT*       out,
+                                         uint32_t     ld,
+                                         DataT        param1,
+                                         DataT        param2)
     {
     }
 
@@ -102,13 +102,13 @@ namespace rocwmma
                                  DataLayout,
                                  Constants::AMDGCN_WAVE_SIZE,
                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixSyncB(uint32_t     m,
-                                                                uint32_t     n,
-                                                                DataT const* in,
-                                                                DataT*       out,
-                                                                uint32_t     ld,
-                                                                DataT        param1,
-                                                                DataT        param2)
+    __global__ void LoadStoreMatrixSyncB(uint32_t     m,
+                                         uint32_t     n,
+                                         DataT const* in,
+                                         DataT*       out,
+                                         uint32_t     ld,
+                                         DataT        param1,
+                                         DataT        param2)
     {
         using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
@@ -137,13 +137,13 @@ namespace rocwmma
                                   DataLayout,
                                   Constants::AMDGCN_WAVE_SIZE,
                                   Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixSyncB(uint32_t     m,
-                                                                uint32_t     n,
-                                                                DataT const* in,
-                                                                DataT*       out,
-                                                                uint32_t     ld,
-                                                                DataT        param1,
-                                                                DataT        param2)
+    __global__ void LoadStoreMatrixSyncB(uint32_t     m,
+                                         uint32_t     n,
+                                         DataT const* in,
+                                         DataT*       out,
+                                         uint32_t     ld,
+                                         DataT        param1,
+                                         DataT        param2)
     {
     }
 
@@ -158,13 +158,13 @@ namespace rocwmma
                                  DataLayout,
                                  Constants::AMDGCN_WAVE_SIZE,
                                  Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixSyncAcc(uint32_t     m,
-                                                                  uint32_t     n,
-                                                                  DataT const* in,
-                                                                  DataT*       out,
-                                                                  uint32_t     ld,
-                                                                  DataT        param1,
-                                                                  DataT        param2)
+    __global__ void LoadStoreMatrixSyncAcc(uint32_t     m,
+                                           uint32_t     n,
+                                           DataT const* in,
+                                           DataT*       out,
+                                           uint32_t     ld,
+                                           DataT        param1,
+                                           DataT        param2)
     {
         using Mapping = MappingUtil<BlockM, BlockN, DataT, DataLayout>;
 
@@ -193,13 +193,13 @@ namespace rocwmma
                                   DataLayout,
                                   Constants::AMDGCN_WAVE_SIZE,
                                   Constants::AMDGCN_CURRENT_ARCH_ID>::enable()>* = nullptr>
-    __global__ void __launch_bounds__(256) LoadStoreMatrixSyncAcc(uint32_t     m,
-                                                                  uint32_t     n,
-                                                                  DataT const* in,
-                                                                  DataT*       out,
-                                                                  uint32_t     ld,
-                                                                  DataT        param1,
-                                                                  DataT        param2)
+    __global__ void LoadStoreMatrixSyncAcc(uint32_t     m,
+                                           uint32_t     n,
+                                           DataT const* in,
+                                           DataT*       out,
+                                           uint32_t     ld,
+                                           DataT        param1,
+                                           DataT        param2)
     {
     }
 

--- a/test/unit/device/vector.hpp
+++ b/test/unit/device/vector.hpp
@@ -29,8 +29,8 @@
 
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7;
-static constexpr uint32_t SUCCESS_VALUE = 0;
+static constexpr uint32_t ERROR_VALUE   = 7u;
+static constexpr uint32_t SUCCESS_VALUE = 0u;
 
 namespace rocwmma
 {
@@ -136,7 +136,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -156,8 +157,10 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(5.0f)));
-            err |= (get(vec1, i) != (static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
         }
 
         return err;
@@ -176,7 +179,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(5.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) + static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -195,7 +199,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(5.0f) - static_cast<DataT>(3.0f)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) - static_cast<DataT>(3.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -215,8 +220,10 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(5.0f)));
-            err |= (get(vec1, i) != (static_cast<DataT>(5.0f) - static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(3.0f) - static_cast<DataT>(5.0f)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) - static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(3.0f) - static_cast<DataT>(5.0f)));
         }
 
         return err;
@@ -235,7 +242,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(5.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(5.0f) - static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) - static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -254,7 +262,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -274,8 +283,10 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(5.0f)));
-            err |= (get(vec1, i) != (static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
         }
 
         return err;
@@ -294,7 +305,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(5.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(5.0f) * static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -313,7 +325,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(6.0f) / static_cast<DataT>(3.0f)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(6.0f) / static_cast<DataT>(3.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -333,8 +346,10 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(6.0f)));
-            err |= (get(vec1, i) != (static_cast<DataT>(6.0f) / static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(3.0f) / static_cast<DataT>(6.0f)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(6.0f) / static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(3.0f) / static_cast<DataT>(6.0f)));
         }
 
         return err;
@@ -353,7 +368,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(6.0f)));
             err |= (get(vec1, i) != (static_cast<DataT>(3.0f)));
-            err |= (get(vec2, i) != (static_cast<DataT>(6.0f) / static_cast<DataT>(3.0f)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(6.0f) / static_cast<DataT>(3.0f)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -412,7 +428,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(6u) % static_cast<DataT>(4u)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(6u) % static_cast<DataT>(4u)));
             err |= (get(vec1, i) != (static_cast<DataT>(4u)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -433,7 +450,8 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(6u)));
-            err |= (get(vec1, i) != (static_cast<DataT>(6u) % static_cast<DataT>(4u)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(6u) % static_cast<DataT>(4u)));
         }
 
         return err;
@@ -454,7 +472,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(6u)));
             err |= (get(vec1, i) != (static_cast<DataT>(4u)));
-            err |= (get(vec2, i) != (static_cast<DataT>(6u) % static_cast<DataT>(4u)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(6u) % static_cast<DataT>(4u)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -505,7 +524,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(0x0F) & static_cast<DataT>(0xF0)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) & static_cast<DataT>(0xF0)));
             err |= (get(vec1, i) != (static_cast<DataT>(0xF0)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -526,7 +546,8 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
-            err |= (get(vec1, i) != (static_cast<DataT>(0x0F) & static_cast<DataT>(0xF0)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) & static_cast<DataT>(0xF0)));
         }
 
         return err;
@@ -547,7 +568,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
             err |= (get(vec1, i) != (static_cast<DataT>(0xF0)));
-            err |= (get(vec2, i) != (static_cast<DataT>(0x0F) & static_cast<DataT>(0xF0)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) & static_cast<DataT>(0xF0)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -598,7 +620,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(0x0F) | static_cast<DataT>(0xF0)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) | static_cast<DataT>(0xF0)));
             err |= (get(vec1, i) != (static_cast<DataT>(0xF0)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -619,7 +642,8 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
-            err |= (get(vec1, i) != (static_cast<DataT>(0x0F) | static_cast<DataT>(0xF0)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) | static_cast<DataT>(0xF0)));
         }
 
         return err;
@@ -640,7 +664,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
             err |= (get(vec1, i) != (static_cast<DataT>(0xF0)));
-            err |= (get(vec2, i) != (static_cast<DataT>(0x0F) | static_cast<DataT>(0xF0)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) | static_cast<DataT>(0xF0)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -691,7 +716,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(0x0F) ^ static_cast<DataT>(0xF0)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) ^ static_cast<DataT>(0xF0)));
             err |= (get(vec1, i) != (static_cast<DataT>(0xF0)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -712,7 +738,8 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
-            err |= (get(vec1, i) != (static_cast<DataT>(0x0F) ^ static_cast<DataT>(0xF0)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) ^ static_cast<DataT>(0xF0)));
         }
 
         return err;
@@ -733,7 +760,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
             err |= (get(vec1, i) != (static_cast<DataT>(0xF0)));
-            err |= (get(vec2, i) != (static_cast<DataT>(0x0F) ^ static_cast<DataT>(0xF0)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) ^ static_cast<DataT>(0xF0)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -784,7 +812,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(0x0F) >> static_cast<DataT>(0x03)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) >> static_cast<DataT>(0x03)));
             err |= (get(vec1, i) != (static_cast<DataT>(0x03)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -805,7 +834,8 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
-            err |= (get(vec1, i) != (static_cast<DataT>(0x0F) >> static_cast<DataT>(0x03)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) >> static_cast<DataT>(0x03)));
         }
 
         return err;
@@ -826,7 +856,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
             err |= (get(vec1, i) != (static_cast<DataT>(0x03)));
-            err |= (get(vec2, i) != (static_cast<DataT>(0x0F) >> static_cast<DataT>(0x03)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) >> static_cast<DataT>(0x03)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -877,7 +908,8 @@ namespace rocwmma
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
-            err |= (get(vec0, i) != (static_cast<DataT>(0x0F) << static_cast<DataT>(0x03)));
+            err |= (get(vec0, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) << static_cast<DataT>(0x03)));
             err |= (get(vec1, i) != (static_cast<DataT>(0x03)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
@@ -898,7 +930,8 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
-            err |= (get(vec1, i) != (static_cast<DataT>(0x0F) << static_cast<DataT>(0x03)));
+            err |= (get(vec1, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) << static_cast<DataT>(0x03)));
         }
 
         return err;
@@ -919,7 +952,8 @@ namespace rocwmma
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
             err |= (get(vec1, i) != (static_cast<DataT>(0x03)));
-            err |= (get(vec2, i) != (static_cast<DataT>(0x0F) << static_cast<DataT>(0x03)));
+            err |= (get(vec2, i)
+                    != static_cast<DataT>(static_cast<DataT>(0x0F) << static_cast<DataT>(0x03)));
             err |= (get(vec0, i) == (get(vec1, i)));
             err |= (get(vec1, i) == (get(vec2, i)));
         }
@@ -970,7 +1004,7 @@ namespace rocwmma
         for(uint32_t i = 0; i < VecSize; i++)
         {
             err |= (get(vec0, i) != (static_cast<DataT>(0x0F)));
-            err |= (get(vec1, i) != (static_cast<DataT>(~0x0F)));
+            err |= (get(vec1, i) != static_cast<DataT>(static_cast<DataT>(~0x0F)));
             err |= (get(vec0, i) == (get(vec1, i)));
         }
 

--- a/test/unit/test/vector_test/vector.cpp
+++ b/test/unit/test/vector_test/vector.cpp
@@ -42,7 +42,7 @@ namespace rocwmma
         using Types = typename Base::TestTypes16;
 
         // Vector Sizes.
-        // Test up to VecSize = 128. Anything bigger is impractical.
+        // Test up to VecSize = 64. Anything bigger is impractical.
         using VecSizes = std::tuple<I<1>, I<2>, I<4>, I<8>, I<16>, I<32>, I<64>>;
 
         using KernelParams = typename CombineLists<VecSizes, Types>::Result;
@@ -80,18 +80,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class VectorIteratorTest : public rocwmma::UnitTest
+class VectorTest : public rocwmma::UnitTest
 {
 };
 
-TEST_P(VectorIteratorTest, RunKernel)
+TEST_P(VectorTest, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     KernelTests,
-    VectorIteratorTest,
+    VectorTest,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),


### PR DESCRIPTION
- Slightly reduce binary size
- Remove unit test launch bounds 256 threads as it may go up to 512
- Ensure proper operator result type casting for validation