### PR TITLE
Fix hipRTC sample

### DIFF
--- a/library/include/rocwmma/internal/utils.hpp
+++ b/library/include/rocwmma/internal/utils.hpp
@@ -196,15 +196,15 @@ namespace std
     class numeric_limits
     {
     public:
-        static constexpr T min() noexcept;
-        static constexpr T lowest() noexcept;
-        static constexpr T max() noexcept;
-        static constexpr T epsilon() noexcept;
-        static constexpr T round_error() noexcept;
-        static constexpr T infinity() noexcept;
-        static constexpr T quiet_NaN() noexcept;
-        static constexpr T signaling_NaN() noexcept;
-        static constexpr T denorm_min() noexcept;
+        __HOST_DEVICE__ static constexpr T min() noexcept;
+        __HOST_DEVICE__ static constexpr T lowest() noexcept;
+        __HOST_DEVICE__ static constexpr T max() noexcept;
+        __HOST_DEVICE__ static constexpr T epsilon() noexcept;
+        __HOST_DEVICE__ static constexpr T round_error() noexcept;
+        __HOST_DEVICE__ static constexpr T infinity() noexcept;
+        __HOST_DEVICE__ static constexpr T quiet_NaN() noexcept;
+        __HOST_DEVICE__ static constexpr T signaling_NaN() noexcept;
+        __HOST_DEVICE__ static constexpr T denorm_min() noexcept;
     };
 
     template <bool B, class T = void>
@@ -478,14 +478,10 @@ namespace std
     };
 
     template <typename T, std::size_t _Size>
-    struct is_array<T[_Size]> : public true_type
-    {
-    };
+    struct is_array<T[_Size]> : public true_type{};
 
     template <typename T>
-    struct is_array<T[]> : public true_type
-    {
-    };
+    struct is_array<T[]> : public true_type{};
 
     // decay selectors
     template <typename _Up,

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -60,15 +60,8 @@ function(add_rocwmma_sample TEST_TARGET TEST_SOURCE)
   )
 endfunction()
 
-function(add_rocwmma_rtc_sample TEST_TARGET TEST_SOURCE)
-  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET}"
-                     COMMAND hipcc ARGS -O3 --std=c++14 -o ${TEST_TARGET} -I${ROCWMMA_SAMPLES_INCLUDE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/../library/include/ ${TEST_SOURCE} -ldl
-                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  add_custom_target(${TEST_TARGET} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET})
-endfunction()
-
 # Create sample targets
 add_rocwmma_sample(simple_gemm ${CMAKE_CURRENT_SOURCE_DIR}/simple_gemm.cpp)
 add_rocwmma_sample(sgemmv ${CMAKE_CURRENT_SOURCE_DIR}/sgemmv.cpp)
 add_rocwmma_sample(simple_dlrm ${CMAKE_CURRENT_SOURCE_DIR}/simple_dlrm.cpp)
-add_rocwmma_rtc_sample(hipRTC_gemm ${CMAKE_CURRENT_SOURCE_DIR}/hipRTC_gemm.cpp)
+add_rocwmma_sample(hipRTC_gemm ${CMAKE_CURRENT_SOURCE_DIR}/hipRTC_gemm.cpp)

--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -44,6 +44,20 @@
     }
 #endif
 
+#ifndef CHECK_HIPRTC_ERROR
+#define CHECK_HIPRTC_ERROR(status)                   \
+    if(status != HIPRTC_SUCCESS)                     \
+    {                                                \
+        fprintf(stderr,                              \
+                "hipRTC error: '%s'(%d) at %s:%d\n", \
+                hiprtcGetErrorString(status),        \
+                status,                              \
+                __FILE__,                            \
+                __LINE__);                           \
+        exit(EXIT_FAILURE);                          \
+    }
+#endif
+
 // HIP Host function to retrieve the warp size
 enum hipWarpSize_t : uint32_t
 {
@@ -56,7 +70,7 @@ uint32_t getWarpSize()
 {
     hipDevice_t     mHandle;
     hipDeviceProp_t mProps;
-    uint32_t mWarpSize = hipWarpSize_t::UNSUPPORTED_WARP_SIZE;
+    uint32_t        mWarpSize = hipWarpSize_t::UNSUPPORTED_WARP_SIZE;
 
     CHECK_HIP_ERROR(hipGetDevice(&mHandle));
     CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
@@ -69,10 +83,9 @@ uint32_t getWarpSize()
     default:;
     }
 
-    if( mWarpSize == hipWarpSize_t::UNSUPPORTED_WARP_SIZE)
+    if(mWarpSize == hipWarpSize_t::UNSUPPORTED_WARP_SIZE)
     {
-        std::cerr << "Cannot proceed: unsupported warp sizev detected. Exiting."
-                    << std::endl;
+        std::cerr << "Cannot proceed: unsupported warp sizev detected. Exiting." << std::endl;
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
- Remove assert from call wrappers as they do no not generate code in release mode (with NDEBUG present)
- Insert Constants namespace to access AMDGCN_WAVE_SIZE
- Consolidate call wrapper checks