### PR TITLE
Silence warnings

### DIFF
--- a/library/include/rocwmma/internal/config.hpp
+++ b/library/include/rocwmma/internal/config.hpp
@@ -113,6 +113,12 @@ namespace rocwmma
 #define ROCWMMA_BLOCK_DIM_32_SUPPORTED 0
 #endif
 
+#if defined(NDEBUG)
+#define ROCWMMA_UNSUPPORTED_IMPL(MSG)
+#else
+#define ROCWMMA_UNSUPPORTED_IMPL(MSG) __attribute__((deprecated(MSG)))
+#endif
+
 ///
 /// Sanity checks
 ///

--- a/library/include/rocwmma/internal/dpp_impl.hpp
+++ b/library/include/rocwmma/internal/dpp_impl.hpp
@@ -176,7 +176,7 @@ namespace rocwmma
 
             public:
                 // clang-format off
-                __attribute__((deprecated("amdgcn_dpp_row_bcast is not supported on MI-100")))
+                ROCWMMA_UNSUPPORTED_IMPL("amdgcn_dpp_row_bcast is not supported on gfx908")
                 constexpr static uint32_t opCtrl()
                 {
                     return Traits::DPP_CTRL;
@@ -281,7 +281,7 @@ namespace rocwmma
 
             public:
                 // clang-format off
-                __attribute__((deprecated("amdgcn_dpp_wave_shift1 is not supported on GFX10+")))
+                ROCWMMA_UNSUPPORTED_IMPL("amdgcn_dpp_wave_shift1 is not supported on gfx10+")
                 constexpr static uint32_t opCtrl()
                 {
                     return Traits::DPP_CTRL;
@@ -300,7 +300,7 @@ namespace rocwmma
 
             public:
                 // clang-format off
-                __attribute__((deprecated("amdgcn_dpp_wave_rotate1 is not supported on GFX10+")))
+                ROCWMMA_UNSUPPORTED_IMPL("amdgcn_dpp_wave_rotate1 is not supported on gfx10+")
                 constexpr static uint32_t opCtrl()
                 {
                     return Traits::DPP_CTRL;
@@ -318,7 +318,7 @@ namespace rocwmma
 
             public:
                 // clang-format off
-                __attribute__((deprecated("amdgcn_dpp_row_bcast15 is not supported on GFX10+")))
+                ROCWMMA_UNSUPPORTED_IMPL("amdgcn_dpp_row_bcast15 is not supported on gfx10+")
                 constexpr static uint32_t opCtrl()
                 {
                     return Traits::DPP_CTRL;
@@ -336,7 +336,7 @@ namespace rocwmma
 
             public:
                 // clang-format off
-                __attribute__((deprecated("amdgcn_dpp_row_bcast31 is not supported on MI-100")))
+                ROCWMMA_UNSUPPORTED_IMPL("amdgcn_dpp_row_bcast31 is not supported on gfx10+")
                 constexpr static uint32_t opCtrl()
                 {
                     return Traits::DPP_CTRL;

--- a/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/library/include/rocwmma/internal/mfma_impl.hpp
@@ -653,13 +653,12 @@ namespace rocwmma
             // This implementation is needed to satisfy the MmaSyncTest interface,
             // and WILL not function as intended.
             // MI-100 lacks support for fp64 MFMA instructions.
-            __attribute__((deprecated("fp64 mfma not supported on MI-100")))
-            __device__ static inline auto
-                exec(typename Traits::ARegsT const& regsA,
-                     typename Traits::BRegsT const& regsB,
-                     typename Traits::CRegsT const& regsC)
+            ROCWMMA_UNSUPPORTED_IMPL("fp64 mfma not supported on gfx908")
+            __device__ static inline auto exec(typename Traits::ARegsT const& regsA,
+                                               typename Traits::BRegsT const& regsB,
+                                               typename Traits::CRegsT const& regsC)
 
-                    -> typename Traits::DRegsT const&
+                -> typename Traits::DRegsT const&
             {
                 return regsC;
             }

--- a/test/gemm/gemm_config.hpp
+++ b/test/gemm/gemm_config.hpp
@@ -38,6 +38,8 @@
 #include "gemm_global_mapping.hpp"
 #include "gemm_local_mapping.hpp"
 
+#define __ROCWMMA_GEMM_LAUNCH_BOUNDS__ __launch_bounds__(Constants::AMDGCN_WAVE_SIZE * 4u)
+
 namespace rocwmma
 {
     namespace CooperativeGemm


### PR DESCRIPTION
- Silence warnings for unsupported / deprecated functionality during release builds
- Scale launch bounds thread counts for GEMM kernels to 4 waves.