### PR TITLE
Ensure cross lane functions are device qualified only

### DIFF
--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -104,13 +104,13 @@ namespace rocwmma
                       "BlendOp is unsupported");
 
         template <typename DataT>
-        ROCWMMA_HOST_DEVICE static inline DataT exec(DataT const& src0, DataT const& src1)
+        ROCWMMA_DEVICE static inline DataT exec(DataT const& src0, DataT const& src1)
         {
             return BlendFunc::exec(src0, src1);
         }
 
         template <typename DataT, uint32_t VecSize>
-        ROCWMMA_HOST_DEVICE static void exec(VecT<DataT, VecSize>& src0, DataT const& src1)
+        ROCWMMA_DEVICE static void exec(VecT<DataT, VecSize>& src0, DataT const& src1)
         {
             auto it = makeVectorIterator(src0).begin();
             static_assert(decltype(it)::range() == VecSize,
@@ -126,8 +126,8 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        ROCWMMA_HOST_DEVICE static void exec(VecT<DataT, VecSize>&       src0,
-                                             VecT<DataT, VecSize> const& src1)
+        ROCWMMA_DEVICE static void exec(VecT<DataT, VecSize>&       src0,
+                                        VecT<DataT, VecSize> const& src1)
         {
             auto it0 = makeVectorIterator(src0).begin();
             auto it1 = makeVectorIterator(src1).begin();
@@ -145,7 +145,7 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        ROCWMMA_HOST_DEVICE static void exec(VecT<DataT, VecSize>& src0)
+        ROCWMMA_DEVICE static void exec(VecT<DataT, VecSize>& src0)
         {
             auto it0 = makeVectorIterator(src0).begin();
             static_assert(decltype(it0)::range() == VecSize,
@@ -161,7 +161,7 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        ROCWMMA_HOST_DEVICE static auto exec(VecT<DataT, VecSize> const& src0)
+        ROCWMMA_DEVICE static auto exec(VecT<DataT, VecSize> const& src0)
         {
             VecT<DataT, VecSize> result;
             auto const           itR = makeVectorIterator(src0).begin();

--- a/library/include/rocwmma/internal/permute.hpp
+++ b/library/include/rocwmma/internal/permute.hpp
@@ -83,19 +83,19 @@ namespace rocwmma
                       "PermuteOp is unsupported");
 
         template <typename DataT>
-        ROCWMMA_HOST_DEVICE static DataT exec(DataT const& src, uint32_t laneId)
+        ROCWMMA_DEVICE static DataT exec(DataT const& src, uint32_t laneId)
         {
             return PermuteFunc::exec(src, PermuteOp::threadCtrl(laneId));
         }
 
         template <typename DataT>
-        ROCWMMA_HOST_DEVICE static void exec(DataT& src, uint32_t laneId)
+        ROCWMMA_DEVICE static void exec(DataT& src, uint32_t laneId)
         {
             src = PermuteFunc::exec(src, PermuteOp::threadCtrl(laneId));
         }
 
         template <typename DataT, uint32_t VecSize>
-        ROCWMMA_HOST_DEVICE static void exec(VecT<DataT, VecSize>& src, uint32_t laneId)
+        ROCWMMA_DEVICE static void exec(VecT<DataT, VecSize>& src, uint32_t laneId)
         {
             auto it = makeVectorIterator(src).begin();
             static_assert(decltype(it)::range() == VecSize,
@@ -111,7 +111,7 @@ namespace rocwmma
         }
 
         template <typename DataT, uint32_t VecSize>
-        ROCWMMA_HOST_DEVICE static auto exec(VecT<DataT, VecSize> const& src, uint32_t laneId)
+        ROCWMMA_DEVICE static auto exec(VecT<DataT, VecSize> const& src, uint32_t laneId)
         {
             VecT<DataT, VecSize> result;
             auto                 itW = makeVectorIterator(result).begin();

--- a/library/include/rocwmma/internal/permute_impl.hpp
+++ b/library/include/rocwmma/internal/permute_impl.hpp
@@ -44,7 +44,7 @@ namespace rocwmma
 
         public:
             // Calculate the read element based on thread position.
-            ROCWMMA_HOST_DEVICE static inline uint32_t threadCtrl(uint32_t threadId)
+            ROCWMMA_DEVICE static inline uint32_t threadCtrl(uint32_t threadId)
             {
                 // Make sure that the threadId is within range
                 auto tIdx = threadId % BlockSize;


### PR DESCRIPTION
Cross-lane ops use GPU backends. Should only qualify them for device usage.