### PR TITLE
Resolve fill function ambiguity with uint32_t datatype

### DIFF
--- a/test/common.hpp
+++ b/test/common.hpp
@@ -222,7 +222,7 @@ namespace rocwmma
         }
 
         template <typename DataT>
-        __host__ static inline void fill(DataT* mat, uint32_t m, uint32_t n, DataT value)
+        __host__ static inline void fillVal(DataT* mat, uint32_t m, uint32_t n, DataT value)
         {
 #pragma omp parallel for
             for(int i = 0; i < m * n; ++i) // row
@@ -233,10 +233,10 @@ namespace rocwmma
 
         template <typename DataT>
         __host__ static inline void
-            fill(std::vector<DataT>& mat, uint32_t m, uint32_t n, DataT value)
+            fillVal(std::vector<DataT>& mat, uint32_t m, uint32_t n, DataT value)
         {
             assert(mat.size() == n * m);
-            fill(mat.data(), m, n, value);
+            fillVal(mat.data(), m, n, value);
         }
 
         // fill kernel wrapper for M x N matrix
@@ -262,12 +262,12 @@ namespace rocwmma
         // fill kernel wrapper for M x N matrix for a specific value
         template <typename DataT>
         __host__ static inline void
-            fillLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n, DataT value)
+            fillValLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n, DataT value)
         {
             auto blockDim = dim3(1024, 1, 1);
             auto gridDim  = dim3(ceilDiv(m * n, blockDim.x), 1, 1);
             hipLaunchKernelGGL(
-                (fillKernel<DataT, Layout>), gridDim, blockDim, 0, 0, d_mat, m, n, value);
+                (fillValKernel<DataT, Layout>), gridDim, blockDim, 0, 0, d_mat, m, n, value);
         }
     };
 

--- a/test/device/common.hpp
+++ b/test/device/common.hpp
@@ -259,7 +259,7 @@ namespace rocwmma
 
     // fill kernel for M x N matrix for a specific value
     template <typename DataT, typename Layout>
-    __global__ void fillKernel(DataT* mat, uint32_t m, uint32_t n, DataT value)
+    __global__ void fillValKernel(DataT* mat, uint32_t m, uint32_t n, DataT value)
     {
         uint32_t rowIdx = (blockIdx.x * blockDim.x + threadIdx.x) / n;
         uint32_t colIdx = (blockIdx.x * blockDim.x + threadIdx.x) % n;

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -536,10 +536,10 @@ namespace rocwmma
             MatrixUtil<LayoutA>::fillLaunchKernel(dataInstance->deviceA().get(), mM, mK);
             MatrixUtil<LayoutB>::fillLaunchKernel(dataInstance->deviceB().get(), mK, mN);
             MatrixUtil<LayoutC>::fillLaunchKernel(dataInstance->deviceC().get(), mM, mN);
-            MatrixUtil<LayoutD>::fillLaunchKernel(dataInstance->deviceD().get(),
-                                                  mM,
-                                                  mN,
-                                                  std::numeric_limits<OutputT>::signaling_NaN());
+            MatrixUtil<LayoutD>::fillValLaunchKernel(dataInstance->deviceD().get(),
+                                                     mM,
+                                                     mN,
+                                                     std::numeric_limits<OutputT>::signaling_NaN());
 
             // Copy to host if performing cpu validation
 #if !defined(ROCWMMA_VALIDATE_WITH_ROCBLAS) && defined(ROCWMMA_VALIDATION_TESTS)
@@ -704,7 +704,7 @@ namespace rocwmma
                 dataInstance->copyData(rocwmmaResult, dataInstance->deviceD(), mM * mN);
 
                 // Reset device D with NaN
-                MatrixUtil<LayoutD>::fillLaunchKernel(
+                MatrixUtil<LayoutD>::fillValLaunchKernel(
                     dataInstance->deviceD().get(),
                     mM,
                     mN,

--- a/test/unit/contamination_test/detail/load_contamination.hpp
+++ b/test/unit/contamination_test/detail/load_contamination.hpp
@@ -76,10 +76,10 @@ namespace rocwmma
                                                             std::numeric_limits<DataT>::max());
 
             // Initialize device output data with NaN
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/contamination_test/detail/store_contamination.hpp
+++ b/test/unit/contamination_test/detail/store_contamination.hpp
@@ -72,10 +72,10 @@ namespace rocwmma
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
 
             // Initialize output data on device (padded size, all with marker elements)
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 get<0>(paddedProbSize),
-                                                 get<1>(paddedProbSize),
-                                                 std::numeric_limits<DataT>::max());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    get<0>(paddedProbSize),
+                                                    get<1>(paddedProbSize),
+                                                    std::numeric_limits<DataT>::max());
         }
 
         void validateResultsImpl() final

--- a/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
@@ -161,10 +161,10 @@ namespace rocwmma
             // {
             //     dataInstance->hostIn().get()[i] = i;
             // }
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/fill_fragment_test/detail/fill_fragment.hpp
+++ b/test/unit/fill_fragment_test/detail/fill_fragment.hpp
@@ -62,7 +62,7 @@ namespace rocwmma
             dataInstance->resizeStorage(probsize);
 
             // Initialize matrix data on host
-            MatrixUtil<Layout>::fillLaunchKernel(
+            MatrixUtil<Layout>::fillValLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN, Base::mParam1);
             MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
                                                     Base::mM,

--- a/test/unit/fill_fragment_test/detail/fill_fragment.hpp
+++ b/test/unit/fill_fragment_test/detail/fill_fragment.hpp
@@ -64,10 +64,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN, Base::mParam1);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/layout_test/detail/col_layout.hpp
+++ b/test/unit/layout_test/detail/col_layout.hpp
@@ -59,10 +59,10 @@ namespace rocwmma
             // Initialize data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
 
             // Copy init data to device
             // dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);

--- a/test/unit/layout_test/detail/colnt_layout.hpp
+++ b/test/unit/layout_test/detail/colnt_layout.hpp
@@ -59,10 +59,10 @@ namespace rocwmma
             // Initialize data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
 
             // Copy init data to device
             // dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);

--- a/test/unit/layout_test/detail/row_layout.hpp
+++ b/test/unit/layout_test/detail/row_layout.hpp
@@ -59,10 +59,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl()

--- a/test/unit/layout_test/detail/rownt_layout.hpp
+++ b/test/unit/layout_test/detail/rownt_layout.hpp
@@ -59,10 +59,10 @@ namespace rocwmma
             // Initialize data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
 
             // Copy init data to device
             // dataInstance->copyData(dataInstance->deviceIn(), dataInstance->hostIn(), sizeD);

--- a/test/unit/load_store_matrix_sync_test/detail/load_store_matrix_sync.hpp
+++ b/test/unit/load_store_matrix_sync_test/detail/load_store_matrix_sync.hpp
@@ -59,10 +59,10 @@ namespace rocwmma
             // Initialize data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/map_util_test/detail/map_block_to_matrix.hpp
+++ b/test/unit/map_util_test/detail/map_block_to_matrix.hpp
@@ -55,10 +55,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/map_util_test/detail/map_block_to_matrix_override.hpp
+++ b/test/unit/map_util_test/detail/map_block_to_matrix_override.hpp
@@ -88,10 +88,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/map_util_test/detail/map_matrix_to_data.hpp
+++ b/test/unit/map_util_test/detail/map_matrix_to_data.hpp
@@ -55,10 +55,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/map_util_test/detail/map_matrix_to_data_override.hpp
+++ b/test/unit/map_util_test/detail/map_matrix_to_data_override.hpp
@@ -87,10 +87,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/map_util_test/detail/map_thread_to_matrix.hpp
+++ b/test/unit/map_util_test/detail/map_thread_to_matrix.hpp
@@ -55,10 +55,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final

--- a/test/unit/map_util_test/detail/map_wave_to_matrix.hpp
+++ b/test/unit/map_util_test/detail/map_wave_to_matrix.hpp
@@ -55,10 +55,10 @@ namespace rocwmma
             // Initialize matrix data on host
             MatrixUtil<Layout>::fillLaunchKernel(
                 dataInstance->deviceIn().get(), Base::mM, Base::mN);
-            MatrixUtil<Layout>::fillLaunchKernel(dataInstance->deviceOut().get(),
-                                                 Base::mM,
-                                                 Base::mN,
-                                                 std::numeric_limits<DataT>::signaling_NaN());
+            MatrixUtil<Layout>::fillValLaunchKernel(dataInstance->deviceOut().get(),
+                                                    Base::mM,
+                                                    Base::mN,
+                                                    std::numeric_limits<DataT>::signaling_NaN());
         }
 
         void validateResultsImpl() final


### PR DESCRIPTION
- Differentiate fill functions as 'fillVal' such that there are no overload clashes