### PR TITLE
B32 Utility

### DIFF
--- a/library/include/rocwmma/internal/b32_util.hpp
+++ b/library/include/rocwmma/internal/b32_util.hpp
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef B32_UTIL_HPP
+#define B32_UTIL_HPP
+
+#include "transforms.hpp"
+
+#include "dpp.hpp"
+#include "io_traits.hpp"
+#include "permute.hpp"
+
+namespace rocwmma
+{
+    template <typename DataT>
+    struct b32Util
+    {
+        using PackTraits = detail::PackTraits<DataT>;
+
+        using ExtractedT = typename PackTraits::PackedT;
+        using EmplacedT  = typename PackTraits::UnpackedT;
+        using PackRatio  = typename PackTraits::PackRatio;
+
+        using FootSpace = union
+        {
+            ExtractedT extracted;
+            EmplacedT  emplaced[PackRatio];
+        };
+
+        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
+        __device__ static auto extract(VecT<EmplacedT, VecSize> const& v)
+        {
+            VecT<ExtractedT, VecSize> result;
+            auto const                rIt = makeVectorIterator(v).begin();
+            auto                      wIt = makeVectorIterator(result).begin();
+
+            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
+                          "Unexpected iterator range mismatch");
+
+            static_assert(SelectIdx < (sizeof(ExtractedT) / sizeof(EmplacedT)),
+                          "Invalid index selection");
+
+            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
+            {
+                FootSpace a;
+                a.emplaced[SelectIdx] = get<0>(*rIt);
+                get<0>(*wIt)          = a.extracted;
+            }
+            return result;
+        }
+
+        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
+        __device__ static auto emplace(VecT<ExtractedT, VecSize> const& v)
+        {
+            VecT<EmplacedT, VecSize> result;
+            auto const               rIt = makeVectorIterator(v).begin();
+            auto                     wIt = makeVectorIterator(result).begin();
+
+            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
+                          "Unexpected iterator range mismatch");
+
+            static_assert(SelectIdx < (sizeof(ExtractedT) / sizeof(EmplacedT)),
+                          "Invalid index selection");
+
+            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
+            {
+                FootSpace a;
+                a.extracted  = get<0>(*rIt);
+                get<0>(*wIt) = a.emplaced[SelectIdx];
+            }
+            return result;
+        }
+    };
+
+    template <>
+    struct b32Util<float64_t>
+    {
+        using ExtractedT = float32_t;
+        using EmplacedT  = float64_t;
+
+        using FootSpace = union
+        {
+            ExtractedT extracted[2];
+            EmplacedT  emplaced;
+        };
+
+        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
+        __device__ static auto extract(VecT<EmplacedT, VecSize> const& v)
+        {
+            const uint32_t inflatedSize = VecSize << 1;
+
+            VecT<ExtractedT, inflatedSize> result;
+            auto const                     rIt = makeVectorIterator(v).begin();
+            auto                           wIt = makeVectorIterator(result).begin();
+
+            static_assert(decltype(rIt)::range() == (decltype(wIt)::range() >> 1),
+                          "Unexpected iterator range mismatch");
+
+            static_assert(SelectIdx < (sizeof(EmplacedT) / sizeof(ExtractedT)),
+                          "Invalid index selection");
+
+            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
+            {
+                FootSpace a;
+                a.emplaced         = get<0>(*rIt);
+                get<0>(*wIt)       = a.extracted[0];
+                get<VecSize>(*wIt) = a.extracted[1];
+            }
+            return result;
+        }
+
+        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
+        __device__ static auto emplace(VecT<ExtractedT, VecSize> const& v)
+        {
+            const uint32_t inflatedSize = VecSize << 1;
+
+            VecT<EmplacedT, VecSize> result;
+            auto const               rIt = makeVectorIterator(v).begin();
+            auto                     wIt = makeVectorIterator(result).begin();
+
+            static_assert((decltype(rIt)::range() >> 1) == decltype(wIt)::range(),
+                          "Unexpected iterator range mismatch");
+
+            static_assert(SelectIdx < (sizeof(EmplacedT) / sizeof(ExtractedT)),
+                          "Invalid index selection");
+
+            for(uint32_t i = 0u; i < decltype(wIt)::range(); i++, rIt++, wIt++)
+            {
+                FootSpace a;
+                a.extracted[0] = get<0>(*rIt);
+                a.extracted[1] = get<VecSize>(*rIt);
+                get<0>(*wIt)   = a.emplaced;
+            }
+            return result;
+        }
+    };
+
+} // namespace rocwmma
+
+#endif // B32_UTIL_HPP

--- a/library/include/rocwmma/internal/b32_util.hpp
+++ b/library/include/rocwmma/internal/b32_util.hpp
@@ -187,6 +187,7 @@ namespace rocwmma
             for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
             {
                 FootSpace a;
+                a.emplaced             = get<0>(*wIt);
                 a.extracted[SelectIdx] = get<0>(*rIt);
                 get<0>(*wIt)           = a.emplaced;
             }

--- a/library/include/rocwmma/internal/b32_util.hpp
+++ b/library/include/rocwmma/internal/b32_util.hpp
@@ -91,6 +91,28 @@ namespace rocwmma
             }
             return result;
         }
+
+        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
+        __device__ static auto emplace(VecT<EmplacedT, VecSize>&        dst,
+                                       VecT<ExtractedT, VecSize> const& v)
+        {
+            auto const rIt = makeVectorIterator(v).begin();
+            auto       wIt = makeVectorIterator(dst).begin();
+
+            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
+                          "Unexpected iterator range mismatch");
+
+            static_assert(SelectIdx < (sizeof(EmplacedT) / sizeof(ExtractedT)),
+                          "Invalid index selection");
+
+            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
+            {
+                FootSpace a;
+                a.extracted  = get<0>(*rIt);
+                get<0>(*wIt) = a.emplaced[SelectIdx];
+            }
+            return dst;
+        }
     };
 
     template <>

--- a/library/include/rocwmma/internal/b32_util.hpp
+++ b/library/include/rocwmma/internal/b32_util.hpp
@@ -41,12 +41,11 @@ namespace rocwmma
 
         using ExtractedT = typename PackTraits::PackedT;
         using EmplacedT  = typename PackTraits::UnpackedT;
-        using PackRatio  = typename PackTraits::PackRatio;
 
         using FootSpace = union
         {
             ExtractedT extracted;
-            EmplacedT  emplaced[PackRatio];
+            EmplacedT  emplaced[PackTraits::PackRatio];
         };
 
         template <uint32_t VecSize, uint32_t SelectIdx = 0u>

--- a/library/include/rocwmma/internal/b32_util.hpp
+++ b/library/include/rocwmma/internal/b32_util.hpp
@@ -108,13 +108,11 @@ namespace rocwmma
         template <uint32_t VecSize, uint32_t SelectIdx = 0u>
         __device__ static auto extract(VecT<EmplacedT, VecSize> const& v)
         {
-            const uint32_t inflatedSize = VecSize << 1;
+            VecT<ExtractedT, VecSize> result;
+            auto const                rIt = makeVectorIterator(v).begin();
+            auto                      wIt = makeVectorIterator(result).begin();
 
-            VecT<ExtractedT, inflatedSize> result;
-            auto const                     rIt = makeVectorIterator(v).begin();
-            auto                           wIt = makeVectorIterator(result).begin();
-
-            static_assert(decltype(rIt)::range() == (decltype(wIt)::range() >> 1),
+            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
                           "Unexpected iterator range mismatch");
 
             static_assert(SelectIdx < (sizeof(EmplacedT) / sizeof(ExtractedT)),
@@ -123,9 +121,8 @@ namespace rocwmma
             for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
             {
                 FootSpace a;
-                a.emplaced         = get<0>(*rIt);
-                get<0>(*wIt)       = a.extracted[0];
-                get<VecSize>(*wIt) = a.extracted[1];
+                a.emplaced   = get<0>(*rIt);
+                get<0>(*wIt) = a.extracted[SelectIdx];
             }
             return result;
         }
@@ -133,26 +130,45 @@ namespace rocwmma
         template <uint32_t VecSize, uint32_t SelectIdx = 0u>
         __device__ static auto emplace(VecT<ExtractedT, VecSize> const& v)
         {
-            const uint32_t inflatedSize = VecSize << 1;
-
             VecT<EmplacedT, VecSize> result;
             auto const               rIt = makeVectorIterator(v).begin();
             auto                     wIt = makeVectorIterator(result).begin();
 
-            static_assert((decltype(rIt)::range() >> 1) == decltype(wIt)::range(),
+            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
                           "Unexpected iterator range mismatch");
 
             static_assert(SelectIdx < (sizeof(EmplacedT) / sizeof(ExtractedT)),
                           "Invalid index selection");
 
-            for(uint32_t i = 0u; i < decltype(wIt)::range(); i++, rIt++, wIt++)
+            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
             {
                 FootSpace a;
-                a.extracted[0] = get<0>(*rIt);
-                a.extracted[1] = get<VecSize>(*rIt);
-                get<0>(*wIt)   = a.emplaced;
+                a.extracted[SelectIdx] = get<0>(*rIt);
+                get<0>(*wIt)           = a.emplaced;
             }
             return result;
+        }
+
+        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
+        __device__ static auto emplace(VecT<EmplacedT, VecSize>&        dst,
+                                       VecT<ExtractedT, VecSize> const& v)
+        {
+            auto const rIt = makeVectorIterator(v).begin();
+            auto       wIt = makeVectorIterator(dst).begin();
+
+            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
+                          "Unexpected iterator range mismatch");
+
+            static_assert(SelectIdx < (sizeof(EmplacedT) / sizeof(ExtractedT)),
+                          "Invalid index selection");
+
+            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
+            {
+                FootSpace a;
+                a.extracted[SelectIdx] = get<0>(*rIt);
+                get<0>(*wIt)           = a.emplaced;
+            }
+            return dst;
         }
     };
 

--- a/library/include/rocwmma/internal/transforms_impl.hpp
+++ b/library/include/rocwmma/internal/transforms_impl.hpp
@@ -37,8 +37,9 @@
 
 namespace rocwmma
 {
-    template <typename DataT>
-    __device__ void aos_soa_16x32_vw8_b32_opt(VecT<DataT, 8>& v)
+    template <typename DataT, uint32_t VecSize, uint32_t... Idx>
+    ROCWMMA_DEVICE constexpr static inline auto extractEven(VecT<DataT, VecSize> const& v,
+                                                            detail::SeqT<Idx...>)
     {
         static_assert(sizeof...(Idx) == VecSize / 2u, "Index count must be half the vector size");
         return VecT<DataT, VecSize / 2u>{get<Idx * 2>(v)...};

--- a/library/include/rocwmma/internal/transforms_impl.hpp
+++ b/library/include/rocwmma/internal/transforms_impl.hpp
@@ -38,70 +38,7 @@
 namespace rocwmma
 {
     template <typename DataT>
-    struct Lufi
-    {
-        using PackTraits = detail::PackTraits<DataT>;
-
-        using InflatedT = typename PackTraits::PackedT;
-        using DeflatedT = typename PackTraits::UnpackedT;
-
-        using FootSpace = union
-        {
-            InflatedT inflated;
-            DeflatedT deflated[PackTraits::PackRatio];
-        };
-
-        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
-        __device__ static auto inflate(VecT<DeflatedT, VecSize> const& v)
-        {
-            VecT<InflatedT, VecSize> result;
-            auto const               rIt = makeVectorIterator(v).begin();
-            auto                     wIt = makeVectorIterator(result).begin();
-
-            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
-                          "Unexpected iterator range mismatch");
-
-            static_assert(SelectIdx < (sizeof(InflatedT) / sizeof(DeflatedT)),
-                          "Invalid index selection");
-
-            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
-            {
-                FootSpace a;
-                a.deflated[SelectIdx] = get<0>(*rIt);
-                get<0>(*wIt)          = a.inflated;
-            }
-            return result;
-        }
-
-        template <uint32_t VecSize, uint32_t SelectIdx = 0u>
-        __device__ static auto deflate(VecT<InflatedT, VecSize> const& v)
-        {
-            VecT<DeflatedT, VecSize> result;
-            auto const               rIt = makeVectorIterator(v).begin();
-            auto                     wIt = makeVectorIterator(result).begin();
-
-            static_assert(decltype(rIt)::range() == decltype(wIt)::range(),
-                          "Unexpected iterator range mismatch");
-
-            static_assert(SelectIdx < (sizeof(InflatedT) / sizeof(DeflatedT)),
-                          "Invalid index selection");
-
-            for(uint32_t i = 0u; i < decltype(rIt)::range(); i++, rIt++, wIt++)
-            {
-                FootSpace a;
-                a.inflated   = get<0>(*rIt);
-                get<0>(*wIt) = a.deflated[SelectIdx];
-            }
-            return result;
-        }
-    };
-
-    ///
-    /// AOS -> SOA : Transform from inline VW to ortho VW
-    ///
-    template <typename DataT, uint32_t VecSize, uint32_t... Idx>
-    ROCWMMA_DEVICE constexpr static inline auto extractEven(VecT<DataT, VecSize> const& v,
-                                                            detail::SeqT<Idx...>)
+    __device__ void aos_soa_16x32_vw8_b32_opt(VecT<DataT, 8>& v)
     {
         static_assert(sizeof...(Idx) == VecSize / 2u, "Index count must be half the vector size");
         return VecT<DataT, VecSize / 2u>{get<Idx * 2>(v)...};


### PR DESCRIPTION
Adds utility for extracting non-32-bit data into 32-bit wide elements for cross-lane operations as well as emplacing the extracted data into its original container size.