### PR TITLE
Update rocblas version check to include v3

### DIFF
--- a/test/rocblas_reference.hpp
+++ b/test/rocblas_reference.hpp
@@ -42,7 +42,7 @@
 
 #include <rocblas/rocblas.h>
 
-#if(ROCBLAS_VERSION_MAJOR >= 2) && (ROCBLAS_VERSION_MINOR > 45)
+#if(ROCBLAS_VERSION_MAJOR >= 3) || ((ROCBLAS_VERSION_MAJOR >= 2) && (ROCBLAS_VERSION_MINOR > 45))
 #define ROCBLAS_DATA_TYPE_INVALID
 #endif
 


### PR DESCRIPTION
-rocblas updated version v3, which includes the rocblas_invalid_datatype