### PR TITLE
Auto-instantiate only ad-hoc kernel and resource instances

### DIFF
--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/CMakeLists.txt
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/CMakeLists.txt
@@ -174,8 +174,9 @@ if(ROCWMMA_BUILD_EXTENDED_TESTS)
                                     )
 endif()
 
-# Ad hoc test sources
-set(${ROCWMMA_AD_HOC_TARGET_SOURCES} ${GemmCommonSources}
+# Ad hoc test sources.
+# Note: GemmKernelBase and GemmResource instantiations required.
+set(${ROCWMMA_AD_HOC_TARGET_SOURCES} ${ROCWMMA_COMMON_TEST_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/test/ad_hoc_test.cpp)
 
 # Create targets

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/test/ad_hoc_test.cpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/test/ad_hoc_test.cpp
@@ -92,22 +92,6 @@ namespace rocwmma
         }
     };
 
-    // Kernel_PGR0_LB0_MP0_MB_NC<
-    //             std::tuple_element_t<BlockM, TestParamsT>::value, // BlockM
-    //             std::tuple_element_t<BlockN, TestParamsT>::value, // BlockN
-    //             std::tuple_element_t<BlockK, TestParamsT>::value, // BlockK
-    //             std::tuple_element_t<InputT, TestParamsT>, // InputT
-    //             std::tuple_element_t<OutputT, TestParamsT>, // OutputT
-    //             std::tuple_element_t<ComputeT, TestParamsT>, // ComputeT
-    //             std::tuple_element_t<LayoutA, TestParamsT>, // LayoutA
-    //             std::tuple_element_t<LayoutB, TestParamsT>, // LayoutB
-    //             std::tuple_element_t<LayoutCD, TestParamsT>, // LayoutC
-    //             std::tuple_element_t<LayoutCD, TestParamsT>, // LayoutD
-    //             std::tuple_element_t<BlocksX, TestParamsT>::value, // BlocksX
-    //             std::tuple_element_t<BlocksY, TestParamsT>::value // BlocksY
-    //             >;
-    // template struct TestParams::GeneratorImpl::Kernel_PGR0_LB0_MP0_MB_NC<std::tuple_element_t<0, TestParams::KernelParams>>;
-
 } // namespace rocwmma
 
 ROCWMMA_INSTANTIATE_GEMM_GTEST_SUITE_NO_WARMUP(Gemm_PGR0_LB0_MP0_MB_NC,

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/test/ad_hoc_test.cpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/test/ad_hoc_test.cpp
@@ -26,9 +26,18 @@
 
 #include "test/test_includes.hpp"
 
+// Instantiate referenced kernels for
+// ad-hoc test only
+#include "gemm_kernel_base_impl.hpp"
+#include "gemm_resource_impl.hpp"
 namespace rocwmma
 {
+    bool KernelI::sHeaderPrinted = false;
+}
 
+namespace rocwmma
+{
+    
     struct TestParams : public CommonTestParams
     {
         using Base = CommonTestParams;
@@ -82,6 +91,22 @@ namespace rocwmma
             };
         }
     };
+
+    // Kernel_PGR0_LB0_MP0_MB_NC<
+    //             std::tuple_element_t<BlockM, TestParamsT>::value, // BlockM
+    //             std::tuple_element_t<BlockN, TestParamsT>::value, // BlockN
+    //             std::tuple_element_t<BlockK, TestParamsT>::value, // BlockK
+    //             std::tuple_element_t<InputT, TestParamsT>, // InputT
+    //             std::tuple_element_t<OutputT, TestParamsT>, // OutputT
+    //             std::tuple_element_t<ComputeT, TestParamsT>, // ComputeT
+    //             std::tuple_element_t<LayoutA, TestParamsT>, // LayoutA
+    //             std::tuple_element_t<LayoutB, TestParamsT>, // LayoutB
+    //             std::tuple_element_t<LayoutCD, TestParamsT>, // LayoutC
+    //             std::tuple_element_t<LayoutCD, TestParamsT>, // LayoutD
+    //             std::tuple_element_t<BlocksX, TestParamsT>::value, // BlocksX
+    //             std::tuple_element_t<BlocksY, TestParamsT>::value // BlocksY
+    //             >;
+    // template struct TestParams::GeneratorImpl::Kernel_PGR0_LB0_MP0_MB_NC<std::tuple_element_t<0, TestParams::KernelParams>>;
 
 } // namespace rocwmma
 

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/CMakeLists.txt
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/CMakeLists.txt
@@ -47,7 +47,8 @@ set(${ROCWMMA_TARGET_SOURCES} ${GemmCommonSources}
                           )
 
 # Ad hoc test
-set(${ROCWMMA_AD_HOC_TARGET_SOURCES} ${GemmCommonSources}
+# Note: GemmKernelBase and GemmResource instantiations required.
+set(${ROCWMMA_AD_HOC_TARGET_SOURCES} ${ROCWMMA_COMMON_TEST_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/test/ad_hoc_test.cpp)
 
 # Create targets

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/test/ad_hoc_test.cpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/test/ad_hoc_test.cpp
@@ -30,6 +30,15 @@
 /// Kernel ad-hoc tests, with manual overrides to test specific parameters quickly.
 ///
 
+// Instantiate referenced kernels for
+// ad-hoc test only
+#include "gemm_kernel_base_impl.hpp"
+#include "gemm_resource_impl.hpp"
+namespace rocwmma
+{
+    bool KernelI::sHeaderPrinted = false;
+}
+
 namespace rocwmma
 {
 

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/CMakeLists.txt
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/CMakeLists.txt
@@ -44,7 +44,8 @@ add_subdirectory(test/wave)
 add_subdirectory(test/workgroup)
 
 # Ad hoc test
-set(${ROCWMMA_AD_HOC_TARGET_SOURCES} ${GemmCommonSources}
+# Note: GemmKernelBase and GemmResource instantiations required.
+set(${ROCWMMA_AD_HOC_TARGET_SOURCES} ${ROCWMMA_COMMON_TEST_SOURCES}
                                      ${CMAKE_CURRENT_SOURCE_DIR}/test/ad_hoc_test.cpp)
 
 add_gemm_test(${ROCWMMA_AD_HOC_TARGET_NAME} ${${ROCWMMA_AD_HOC_TARGET_SOURCES}})

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/test/ad_hoc_test.cpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/test/ad_hoc_test.cpp
@@ -30,6 +30,15 @@
 /// Kernel ad-hoc tests, with manual overrides to test specific parameters quickly.
 ///
 
+// Instantiate referenced kernels for
+// ad-hoc test only
+#include "gemm_kernel_base_impl.hpp"
+#include "gemm_resource_impl.hpp"
+namespace rocwmma
+{
+    bool KernelI::sHeaderPrinted = false;
+}
+
 namespace rocwmma
 {
 


### PR DESCRIPTION
- Don't link manual instantiations for full test suite
- Instantiate only instances of GemmKernelBase and GemmResource, such that specific kernels are only included in the assembly (easier for investigation)