### PR TITLE
Samples fixup for gfx11

### DIFF
--- a/library/include/rocwmma/internal/type_traits.hpp
+++ b/library/include/rocwmma/internal/type_traits.hpp
@@ -327,9 +327,7 @@ namespace std
 
     // __is_referenceable
     template <typename T>
-    struct __is_referenceable : public __or_<is_object<T>, is_reference<T>>::type
-    {
-    };
+    struct __is_referenceable : public __or_<is_object<T>, is_reference<T>>::type{};
 
     // add_pointer
     template <typename T, bool = __or_<__is_referenceable<T>, is_void<T>>::value>
@@ -398,6 +396,9 @@ namespace std
     public:
         typedef typename __decay_selector<__remove_type>::__type type;
     };
+
+    template <typename T>
+    using decay_t = typename decay<T>::type;
 
 } // namespace std
 #endif

--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -73,6 +73,20 @@ bool isF64Supported()
     return (deviceName.find("gfx90a") != std::string::npos);
 }
 
+bool isF32Supported()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return (deviceName.find("gfx908") != std::string::npos)
+           || (deviceName.find("gfx90a") != std::string::npos);
+}
+
 inline double calculateGFlops(uint32_t m, uint32_t n, uint32_t k)
 {
     return 2.0 * static_cast<double>(m) * static_cast<double>(n) * static_cast<double>(k) * 1.0e-9;

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -854,6 +854,13 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
 
 int main()
 {
-    gemm_test(7168, 7168, 7168, 2, 2);
+    if(!isF32Supported())
+    {
+        std::cout << "f32 sgemm not supported on this device" << std::endl;
+    }
+    else
+    {
+        gemm_test(7168, 7168, 7168, 2, 2);
+    }
     return 0;
 }

--- a/samples/simple_sgemm.cpp
+++ b/samples/simple_sgemm.cpp
@@ -288,6 +288,13 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
 
 int main()
 {
-    gemm_test(256, 256, 256, 2.1f, 2.1f);
+    if(!isF32Supported())
+    {
+        std::cout << "f32 sgemm not supported on this device" << std::endl;
+    }
+    else
+    {
+        gemm_test(256, 256, 256, 2.1f, 2.1f);
+    }
     return 0;
 }


### PR DESCRIPTION
- hipRTC needed implementation for std::decay_t
- sgem* samples skipped on gfx11 targets due to unsupported f32 inputs