### PR TITLE
Fix Doxygen output documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ _static/
 _templates/
 _toc.yml
 docBin/
+_doxygen/

--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -2064,7 +2064,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = __device__
+PREDEFINED             = __device__ ROCWMMA_DEVICE
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/API_Reference_Guide.rst
+++ b/docs/API_Reference_Guide.rst
@@ -434,12 +434,6 @@ VecT
 
 
 
-VectorStorage
-'''''''''''''
-
-.. doxygenstruct:: rocwmma::detail::VectorStorage
-
-
 IOConfig
 ''''''''''''
 


### PR DESCRIPTION
add ROCWMMA_DEVICE macro to Doxyfile PREDEFINED macros so that the documentation is generated correctly for anything that uses that macro

also remove reference to the VectorStorage struct in documentation that does not appear in source code