### PR TITLE
Enable rocm_smi only to benchmark (#195)

### DIFF
--- a/test/common.hpp
+++ b/test/common.hpp
@@ -51,7 +51,7 @@
     }
 #endif
 
-
+#ifdef ROCWMMA_BENCHMARK_TESTS
 #ifndef CHECK_RSMI_ERROR
 #define CHECK_RSMI_ERROR(status)                            \
     if(status != RSMI_STATUS_SUCCESS )                      \
@@ -66,6 +66,7 @@
                 __LINE__);                                  \
         exit(EXIT_FAILURE);                                 \
     }
+#endif
 #endif
 
 namespace rocwmma

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -38,33 +38,33 @@
 #include "device/common.hpp"
 
 #ifndef CHECK_HIP_ERROR
-#define CHECK_HIP_ERROR(status)                   \
-    if(status != hipSuccess)                      \
-    {                                             \
-        fprintf(stderr,                           \
-                "hip error: '%s'(%d) at %s:%d\n", \
-                hipGetErrorString(status),        \
-                status,                           \
-                __FILE__,                         \
-                __LINE__);                        \
-        exit(EXIT_FAILURE);                       \
+#define CHECK_HIP_ERROR(expression)                      \
+    if(auto status = (expression); status != hipSuccess) \
+    {                                                    \
+        fprintf(stderr,                                  \
+                "hip error: '%s'(%d) at %s:%d\n",        \
+                hipGetErrorString(status),               \
+                status,                                  \
+                __FILE__,                                \
+                __LINE__);                               \
+        exit(EXIT_FAILURE);                              \
     }
 #endif
 
 #ifdef ROCWMMA_BENCHMARK_TESTS
 #ifndef CHECK_RSMI_ERROR
-#define CHECK_RSMI_ERROR(status)                            \
-    if(status != RSMI_STATUS_SUCCESS )                      \
-    {                                                       \
-        const char* errName = nullptr;                      \
-        rsmi_status_string(status, &errName);               \
-        fprintf(stderr,                                     \
-                "rsmi error: '%s'(%d) at %s:%d\n",          \
-                errName,                                    \
-                status,                                     \
-                __FILE__,                                   \
-                __LINE__);                                  \
-        exit(EXIT_FAILURE);                                 \
+#define CHECK_RSMI_ERROR(expression)                              \
+    if(auto status = (expression); status != RSMI_STATUS_SUCCESS) \
+    {                                                             \
+        const char* errName = nullptr;                            \
+        rsmi_status_string(status, &errName);                     \
+        fprintf(stderr,                                           \
+                "rsmi error: '%s'(%d) at %s:%d\n",                \
+                errName,                                          \
+                status,                                           \
+                __FILE__,                                         \
+                __LINE__);                                        \
+        exit(EXIT_FAILURE);                                       \
     }
 #endif
 #endif

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -53,18 +53,18 @@
 
 #ifdef ROCWMMA_BENCHMARK_TESTS
 #ifndef CHECK_RSMI_ERROR
-#define CHECK_RSMI_ERROR(expression)                              \
-    if(auto status = (expression); status != RSMI_STATUS_SUCCESS) \
-    {                                                             \
-        const char* errName = nullptr;                            \
-        rsmi_status_string(status, &errName);                     \
-        fprintf(stderr,                                           \
-                "rsmi error: '%s'(%d) at %s:%d\n",                \
-                errName,                                          \
-                status,                                           \
-                __FILE__,                                         \
-                __LINE__);                                        \
-        exit(EXIT_FAILURE);                                       \
+#define CHECK_RSMI_ERROR(expression, smiErrorFlag)                        \
+    if(auto status = (expression); status != RSMI_STATUS_SUCCESS)         \
+    {                                                                     \
+        const char* errName = nullptr;                                    \
+        rsmi_status_string(status, &errName);                             \
+        fprintf(stderr,                                                   \
+                "rsmi error: '%s'(%d) at %s:%d\n",                        \
+                errName,                                                  \
+                status,                                                   \
+                __FILE__,                                                 \
+                __LINE__);                                                \
+        smiErrorFlag = true;                                              \
     }
 #endif
 #endif

--- a/test/hip_device.cpp
+++ b/test/hip_device.cpp
@@ -78,6 +78,7 @@ namespace rocwmma
         mCuCount       = mProps.multiProcessorCount;
         mMaxFreqMhz    = static_cast<int>(static_cast<double>(mProps.clockRate) / 1000.0);
 
+#ifdef ROCWMMA_BENCHMARK_TESTS
         CHECK_RSMI_ERROR(rsmi_init(0));
         uint64_t hipPCIID = 0;
         hipPCIID |= mProps.pciDeviceID & 0xFF;
@@ -104,6 +105,9 @@ namespace rocwmma
         CHECK_RSMI_ERROR(rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, RSMI_CLK_TYPE_SYS, &freq));
 
         mCurFreqMhz = freq.frequency[freq.current] / 1000000;
+#else
+        mCurFreqMhz = mMaxFreqMhz;
+#endif
 }
 
     hipDevice_t HipDevice::getDeviceHandle() const
@@ -153,7 +157,9 @@ namespace rocwmma
 
     HipDevice::~HipDevice()
     {
+#ifdef ROCWMMA_BENCHMARK_TESTS
         CHECK_RSMI_ERROR(rsmi_shut_down());
+#endif
     }
 
     // Need to check the host device target support statically before hip modules attempt


### PR DESCRIPTION
Propagating the fix to enable rocm-smi only during benchmark for ROCm 5.7