### PR TITLE
Validation of float8 and bfloat8 gemm tests

### DIFF
--- a/library/include/rocwmma/internal/float8.h
+++ b/library/include/rocwmma/internal/float8.h
@@ -149,17 +149,6 @@ struct rocwmma_f8
     {
     }
 
-    /* TODO : Fix bfloat16 visibility 
-    // constructor from bfloat16
-    explicit ROCWMMA_HOST_DEVICE rocwmma_f8(rocwmma::bfloat16_t             v,
-                                            rocwmma_hip_f8_rounding_mode rm
-                                            = rocwmma_hip_f8_rounding_mode::standard,
-                                            uint32_t rng = 0)
-                                : rocwmma_f8((float)v, rm, rng)
-    {
-    }
-    */
-
     // constructor from int
     explicit ROCWMMA_HOST_DEVICE rocwmma_f8(int                          v,
                                             rocwmma_hip_f8_rounding_mode rm
@@ -215,14 +204,6 @@ struct rocwmma_f8
         return _Float16(float(*this)); // convert to float, then convert to f16
     }
 
-    /* TODO : Fix bfloat16 visibility 
-    // convert to bfloat16
-    explicit inline ROCWMMA_HOST_DEVICE operator rocwmma::bfloat16_t() const
-    {
-        return rocwmma::bfloat16_t(float(*this)); // convert to float, then convert to f16
-    }
-    */
-
     inline ROCWMMA_HOST_DEVICE rocwmma_f8 operator- ()
     {
         this->data ^= 0x80;
@@ -246,15 +227,6 @@ struct rocwmma_f8
     {
         return data == 0x80;
     }
-
-    /* TODO : Copy assignment to default - check 
-    // assignment overloading only from the same F8 types
-    inline ROCWMMA_HOST_DEVICE rocwmma_f8& operator=(const rocwmma_f8& a)
-    {
-        data = a.data;
-        return *this;
-    }
-    */
 };
 
 struct  rocwmma_bf8
@@ -360,17 +332,6 @@ struct  rocwmma_bf8
     {
     }
 
-    /* TODO : Fix bfloat16 visibility 
-    // constructor from bfloat16
-    explicit ROCWMMA_HOST_DEVICE rocwmma_bf8(rocwmma::bfloat16_t             v,
-                                             rocwmma_hip_f8_rounding_mode rm
-                                             = rocwmma_hip_f8_rounding_mode::standard,
-                                             uint32_t rng = 0)
-                                    : rocwmma_bf8((float)v, rm, rng)
-    {
-    }
-    */
-
     // constructor from int
     explicit ROCWMMA_HOST_DEVICE rocwmma_bf8(int                          v,
                                              rocwmma_hip_f8_rounding_mode rm
@@ -379,6 +340,16 @@ struct  rocwmma_bf8
                                     : rocwmma_bf8((float)v, rm, rng)
     {
     }
+
+    // constructor from unsigned int
+    explicit ROCWMMA_HOST_DEVICE rocwmma_bf8(unsigned int                 v,
+                                             rocwmma_hip_f8_rounding_mode rm
+                                             = rocwmma_hip_f8_rounding_mode::standard,
+                                             uint32_t rng = 0)
+                                    : rocwmma_bf8((float)v, rm, rng)
+    {
+    }
+
     // constructor from double
     explicit ROCWMMA_HOST_DEVICE rocwmma_bf8(double                       v,
                                              rocwmma_hip_f8_rounding_mode rm
@@ -415,13 +386,11 @@ struct  rocwmma_bf8
         return _Float16(float(*this)); // convert to float, then convert to f16
     }
 
-    /* TODO : Fix bfloat16 visibility 
-    // convert to bfloat16
-    explicit inline ROCWMMA_HOST_DEVICE operator rocwmma::bfloat16_t() const
+    inline ROCWMMA_HOST_DEVICE rocwmma_bf8 operator- ()
     {
-        return rocwmma::bfloat16_t(float(*this)); // convert to float, then convert to f16
+        this->data ^= 0x80;
+        return *this;
     }
-    */
 
     // check for zero
     inline ROCWMMA_HOST_DEVICE bool is_zero() const
@@ -440,15 +409,6 @@ struct  rocwmma_bf8
     {
         return data == 0x80;
     }
-
-    /* TODO : Copy assignment to default - check      
-    // assignment overloading only from the same F8 types
-    inline ROCWMMA_HOST_DEVICE rocwmma_bf8& operator=(const rocwmma_bf8& a)
-    {
-        data = a.data;
-        return *this;
-    }
-    */
 };
 
 namespace std

--- a/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/library/include/rocwmma/internal/mfma_impl.hpp
@@ -783,6 +783,67 @@ namespace rocwmma
             }
         };
 
+#else // !ROCWMMA_ARCH_GFX940
+
+        // Required for general fp8 support
+        template <>
+        struct amdgcn_mfma<float8_t, float32_t, 16, 16>
+        {
+            // Packed register traits
+            struct Traits
+            {
+                enum : uint32_t
+                {
+                    KPerMfma = 32
+                };
+                using ARegsT = VRegF32x2;
+                using BRegsT = VRegF32x2;
+                using CRegsT = AccRegF32x4;
+                using DRegsT = AccRegF32x4;
+            };
+
+            // This implementation is needed to satisfy the MmaSyncTest interface,
+            // and WILL not function as intended.
+            // gfx908 and gfx90a lacks support for fp8 MFMA instructions.
+            ROCWMMA_UNSUPPORTED_IMPL("fp8 mfma not supported on gfx908/gfx90a")
+            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
+                                                   typename Traits::BRegsT const& regsB,
+                                                   typename Traits::CRegsT const& regsC)
+
+                -> typename Traits::DRegsT const&
+            {
+                return regsC;
+            }
+        };
+
+        template <>
+        struct amdgcn_mfma<float8_t, float32_t, 32, 32>
+        {
+            // Packed register traits
+            struct Traits
+            {
+                enum : uint32_t
+                {
+                    KPerMfma = 16
+                };
+                using ARegsT = VRegF32x2;
+                using BRegsT = VRegF32x2;
+                using CRegsT = AccRegF32x16;
+                using DRegsT = AccRegF32x16;
+            };
+
+            // This implementation is needed to satisfy the MmaSyncTest interface,
+            // and WILL not function as intended.
+            // gfx908 and gfx90a lacks support for fp8 MFMA instructions.
+            ROCWMMA_UNSUPPORTED_IMPL("fp8 mfma not supported on gfx908/gfx90a")
+            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
+                                                   typename Traits::BRegsT const& regsB,
+                                                   typename Traits::CRegsT const& regsC) ->
+                typename Traits::DRegsT
+            {
+                return regsC;
+            }
+        };
 #endif // ROCWMMA_ARCH_GFX940
 
 #endif // ROCWMMA_ARCH_MI

--- a/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/library/include/rocwmma/internal/mfma_impl.hpp
@@ -747,8 +747,9 @@ namespace rocwmma
                 typename Traits::DRegsT
             {
                 typename Traits::DRegsT result;
+                using inputType = VRegI64x1;
                 result.data = {__builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(
-                    regsA.data[0], regsB.data[0], regsC.data, 0, 0, 0)};
+                    ((inputType const&)(regsA)).data[0], ((inputType const&)(regsB)).data[0], regsC.data, 0, 0, 0)};
                 return result;
             }
         };
@@ -775,8 +776,9 @@ namespace rocwmma
                 typename Traits::DRegsT
             {
                 typename Traits::DRegsT result;
+                using inputType = VRegI64x1;
                 result.data = {__builtin_amdgcn_mfma_f32_32x32x16_fp8_fp8(
-                    regsA.data[0], regsB.data[0], regsC.data, 0, 0, 0)};
+                    ((inputType const&)(regsA)).data[0], ((inputType const&)(regsB)).data[0], regsC.data, 0, 0, 0)};
                 return result;
             }
         };

--- a/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/library/include/rocwmma/internal/mfma_impl.hpp
@@ -783,6 +783,64 @@ namespace rocwmma
             }
         };
 
+        template <>
+        struct amdgcn_mfma<bfloat8_t, float32_t, 16, 16>
+        {
+            // Packed register traits
+            struct Traits
+            {
+                enum : uint32_t
+                {
+                    KPerMfma = 32
+                };
+                using ARegsT = VRegF32x2;
+                using BRegsT = VRegF32x2;
+                using CRegsT = AccRegF32x4;
+                using DRegsT = AccRegF32x4;
+            };
+
+            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
+                                                   typename Traits::BRegsT const& regsB,
+                                                   typename Traits::CRegsT const& regsC) ->
+                typename Traits::DRegsT
+            {
+                typename Traits::DRegsT result;
+                using inputType = VRegI64x1;
+                result.data = {__builtin_amdgcn_mfma_f32_16x16x32_bf8_bf8(
+                    ((inputType const&)(regsA)).data[0], ((inputType const&)(regsB)).data[0], regsC.data, 0, 0, 0)};
+                return result;
+            }
+        };
+
+        template <>
+        struct amdgcn_mfma<bfloat8_t, float32_t, 32, 32>
+        {
+            // Packed register traits
+            struct Traits
+            {
+                enum : uint32_t
+                {
+                    KPerMfma = 16
+                };
+                using ARegsT = VRegF32x2;
+                using BRegsT = VRegF32x2;
+                using CRegsT = AccRegF32x16;
+                using DRegsT = AccRegF32x16;
+            };
+
+            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
+                                                   typename Traits::BRegsT const& regsB,
+                                                   typename Traits::CRegsT const& regsC) ->
+                typename Traits::DRegsT
+            {
+                typename Traits::DRegsT result;
+                using inputType = VRegI64x1;
+                result.data = {__builtin_amdgcn_mfma_f32_32x32x16_bf8_bf8(
+                    ((inputType const&)(regsA)).data[0], ((inputType const&)(regsB)).data[0], regsC.data, 0, 0, 0)};
+                return result;
+            }
+        };
+
 #else // !ROCWMMA_ARCH_GFX940
 
         // Required for general fp8 support
@@ -844,6 +902,67 @@ namespace rocwmma
                 return regsC;
             }
         };
+
+        // Required for general bf8 support
+        template <>
+        struct amdgcn_mfma<bfloat8_t, float32_t, 16, 16>
+        {
+            // Packed register traits
+            struct Traits
+            {
+                enum : uint32_t
+                {
+                    KPerMfma = 32
+                };
+                using ARegsT = VRegF32x2;
+                using BRegsT = VRegF32x2;
+                using CRegsT = AccRegF32x4;
+                using DRegsT = AccRegF32x4;
+            };
+
+            // This implementation is needed to satisfy the MmaSyncTest interface,
+            // and WILL not function as intended.
+            // gfx908 and gfx90a lacks support for bf8 MFMA instructions.
+            ROCWMMA_UNSUPPORTED_IMPL("bf8 mfma not supported on gfx908/gfx90a")
+            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
+                                                   typename Traits::BRegsT const& regsB,
+                                                   typename Traits::CRegsT const& regsC)
+
+                -> typename Traits::DRegsT const&
+            {
+                return regsC;
+            }
+        };
+
+        template <>
+        struct amdgcn_mfma<bfloat8_t, float32_t, 32, 32>
+        {
+            // Packed register traits
+            struct Traits
+            {
+                enum : uint32_t
+                {
+                    KPerMfma = 16
+                };
+                using ARegsT = VRegF32x2;
+                using BRegsT = VRegF32x2;
+                using CRegsT = AccRegF32x16;
+                using DRegsT = AccRegF32x16;
+            };
+
+            // This implementation is needed to satisfy the MmaSyncTest interface,
+            // and WILL not function as intended.
+            // gfx908 and gfx90a lacks support for bf8 MFMA instructions.
+            ROCWMMA_UNSUPPORTED_IMPL("bf8 mfma not supported on gfx908/gfx90a")
+            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
+                                                   typename Traits::BRegsT const& regsB,
+                                                   typename Traits::CRegsT const& regsC) ->
+                typename Traits::DRegsT
+            {
+                return regsC;
+            }
+        };
+
 #endif // ROCWMMA_ARCH_GFX940
 
 #endif // ROCWMMA_ARCH_MI

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_predicates.hpp
@@ -63,9 +63,10 @@ namespace rocwmma
             CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
             BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
-                         (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value) &&
-                        (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
-                        (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
+                         (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value
+                         || std::is_same<InputT, bfloat8_t>::value) &&
+                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
+                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
 
             Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64
                       && CostABTest && CostCTest && CostDTest && BlockKTest)

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_predicates.hpp
@@ -62,7 +62,8 @@ namespace rocwmma
             CostCTest = ((uint32_t)TestTraits::Cost::TileC <= 256u),
             CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
-            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 && std::is_same<InputT, int8_t>::value &&
+            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
+                         (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value) &&
                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
 

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_predicates.hpp
@@ -61,7 +61,8 @@ namespace rocwmma
             CostCTest = ((uint32_t)TestTraits::Cost::TileC <= 256u),
             CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
-            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 && std::is_same<InputT, int8_t>::value &&
+            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
+                        (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value) &&
                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
 

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_predicates.hpp
@@ -62,7 +62,8 @@ namespace rocwmma
             CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
             BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
-                        (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value) &&
+                        (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value
+                        || std::is_same<InputT, bfloat8_t>::value) &&
                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
 

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
@@ -81,7 +81,8 @@ namespace rocwmma
                              + 2u * (uint32_t)TestTraits::Cost::TileD)
                             <= 256u),
 
-            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 && std::is_same<InputT, int8_t>::value &&
+            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
+                        ( std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value) &&
                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
 

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
@@ -82,7 +82,8 @@ namespace rocwmma
                             <= 256u),
 
             BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
-                        ( std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value) &&
+                        ( std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value
+                        || std::is_same<InputT, bfloat8_t>::value) &&
                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
 

--- a/test/gemm/gemm_common_test_params.hpp
+++ b/test/gemm/gemm_common_test_params.hpp
@@ -56,7 +56,7 @@ namespace rocwmma
 
         // float8
         using TestTypesF8 = std::tuple<
-            std::tuple<float8_t, float8_t, float32_t>>;
+            std::tuple<float8_t, float32_t, float32_t>>;
 
         // Non-native bfloat16_t
         using TestTypesBF16 = std::tuple<

--- a/test/gemm/gemm_common_test_params.hpp
+++ b/test/gemm/gemm_common_test_params.hpp
@@ -58,6 +58,10 @@ namespace rocwmma
         using TestTypesF8 = std::tuple<
             std::tuple<float8_t, float32_t, float32_t>>;
 
+        // bfloat8
+        using TestTypesBF8 = std::tuple<
+            std::tuple<bfloat8_t, float32_t, float32_t>>;
+
         // Non-native bfloat16_t
         using TestTypesBF16 = std::tuple<
 #if defined(ROCWMMA_EXTENDED_TESTS)
@@ -89,11 +93,11 @@ namespace rocwmma
         using TestTypesF64 = std::tuple<std::tuple<float64_t, float64_t, float64_t>>;
 
         // Aggregate types <= 8 bit
-        using TestTypesTiny = typename Concat<TestTypesF8, TestTypesI8>::Result;
+        using TestTypesTiny = typename Concat<TestTypesF8, TestTypesBF8, TestTypesI8>::Result;
 
         // Aggregate types <= 16 bit
         using TestTypesSmall =
-            typename Concat<TestTypesF8, TestTypesI8, TestTypesBF16, TestTypesF16, TestTypesH16>::Result;
+            typename Concat<TestTypesTiny, TestTypesBF16, TestTypesF16, TestTypesH16>::Result;
 
         // Aggregate types <= 32 bit
         using TestTypesMedium = typename Concat<TestTypesSmall, TestTypesF32>::Result;

--- a/test/gemm/gemm_common_test_params.hpp
+++ b/test/gemm/gemm_common_test_params.hpp
@@ -54,6 +54,10 @@ namespace rocwmma
 #endif // ROCWMMA_EXTENDED_TESTS
             std::tuple<int8_t, int32_t, int32_t>>;
 
+        // float8
+        using TestTypesF8 = std::tuple<
+            std::tuple<float8_t, float8_t, float32_t>>;
+
         // Non-native bfloat16_t
         using TestTypesBF16 = std::tuple<
 #if defined(ROCWMMA_EXTENDED_TESTS)
@@ -85,11 +89,11 @@ namespace rocwmma
         using TestTypesF64 = std::tuple<std::tuple<float64_t, float64_t, float64_t>>;
 
         // Aggregate types <= 8 bit
-        using TestTypesTiny = TestTypesI8;
+        using TestTypesTiny = typename Concat<TestTypesF8, TestTypesI8>::Result;
 
         // Aggregate types <= 16 bit
         using TestTypesSmall =
-            typename Concat<TestTypesI8, TestTypesBF16, TestTypesF16, TestTypesH16>::Result;
+            typename Concat<TestTypesF8, TestTypesI8, TestTypesBF16, TestTypesF16, TestTypesH16>::Result;
 
         // Aggregate types <= 32 bit
         using TestTypesMedium = typename Concat<TestTypesSmall, TestTypesF32>::Result;

--- a/test/gemm/gemm_kernel_base.cpp
+++ b/test/gemm/gemm_kernel_base.cpp
@@ -835,6 +835,7 @@ namespace rocwmma
     // All supported instantiations
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(int8_t, int32_t, int32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float8_t, float32_t, float32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat8_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, float32_t, float32_t);

--- a/test/gemm/gemm_kernel_base.cpp
+++ b/test/gemm/gemm_kernel_base.cpp
@@ -834,6 +834,7 @@ namespace rocwmma
 
     // All supported instantiations
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(int8_t, int32_t, int32_t);
+    ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float8_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, float32_t, float32_t);

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -203,6 +203,7 @@ namespace rocwmma
 
         // Arch
         auto isGfx908 = deviceArch == DeviceInfo::GFX908;
+        auto isGfx90a = deviceArch == DeviceInfo::GFX90A;
         auto isGfx11  = (deviceArch == DeviceInfo::GFX1100) || (deviceArch == DeviceInfo::GFX1101)
                        || (deviceArch == DeviceInfo::GFX1102);
 
@@ -212,6 +213,7 @@ namespace rocwmma
             = (std::is_same<InputT, float16_t>::value) || (std::is_same<InputT, hfloat16_t>::value);
         auto isBF16Input = (std::is_same<InputT, bfloat16_t>::value);
         auto isI8Input   = (std::is_same<InputT, int8_t>::value);
+        auto isF8Input   = (std::is_same<InputT, float8_t>::value);
 
         // Block size
         auto is16x16 = (BlockM == 16 && BlockN == 16);
@@ -220,12 +222,15 @@ namespace rocwmma
         bool unsupportedDeviceCheck = !(deviceArch == DeviceInfo::UNSUPPORTED_ARCH);
 
         // gfx908 doesn't support f64
-        bool gfx908F64Check = !(isGfx908 && isF64Input);
+        bool gfx908F64F8Check = !(isGfx908 && (isF64Input || isF8Input));
+
+        // gfx90a doesn't support f8
+        bool gfx90aF8Check = !(isGfx90a && isF8Input);
 
         // gfx11 only supports f16, i8 and bf16 inputs with block size 16
         bool gfx11Check = !(isGfx11 && ((!isF16Input && !isBF16Input && !isI8Input) || !is16x16));
 
-        return unsupportedDeviceCheck && gfx908F64Check && gfx11Check;
+        return unsupportedDeviceCheck && gfx908F64F8Check && gfx90aF8Check && gfx11Check;
     }
 
     template <uint32_t BlockM,

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -213,7 +213,8 @@ namespace rocwmma
             = (std::is_same<InputT, float16_t>::value) || (std::is_same<InputT, hfloat16_t>::value);
         auto isBF16Input = (std::is_same<InputT, bfloat16_t>::value);
         auto isI8Input   = (std::is_same<InputT, int8_t>::value);
-        auto isF8Input   = (std::is_same<InputT, float8_t>::value);
+        auto isF8Input
+            = (std::is_same<InputT, float8_t>::value) || (std::is_same<InputT, bfloat8_t>::value);
 
         // Block size
         auto is16x16 = (BlockM == 16 && BlockN == 16);

--- a/test/gemm/gemm_resource.cpp
+++ b/test/gemm/gemm_resource.cpp
@@ -30,6 +30,7 @@ namespace rocwmma
     // All supported instantiations
     template struct GemmResource<int8_t, int32_t>;
     template struct GemmResource<float8_t, float32_t>;
+    template struct GemmResource<bfloat8_t, float32_t>;
     template struct GemmResource<bfloat16_t, float32_t>;
     template struct GemmResource<float16_t, float32_t>;
     template struct GemmResource<hfloat16_t, float32_t>;

--- a/test/gemm/gemm_resource.cpp
+++ b/test/gemm/gemm_resource.cpp
@@ -29,6 +29,7 @@ namespace rocwmma
 {
     // All supported instantiations
     template struct GemmResource<int8_t, int32_t>;
+    template struct GemmResource<float8_t, float32_t>;
     template struct GemmResource<bfloat16_t, float32_t>;
     template struct GemmResource<float16_t, float32_t>;
     template struct GemmResource<hfloat16_t, float32_t>;

--- a/test/performance.hpp
+++ b/test/performance.hpp
@@ -50,6 +50,15 @@ namespace rocwmma
     };
 
     template <>
+    struct MfmaPerfTraits<DefaultArch, float8_t>
+    {
+        enum : uint32_t
+        {
+            Multiplier = 0
+        };
+    };
+
+    template <>
     struct MfmaPerfTraits<DefaultArch, bfloat16_t>
     {
         enum : uint32_t
@@ -96,6 +105,15 @@ namespace rocwmma
     };
 
     template <>
+    struct MfmaPerfTraits<MI100, float8_t>
+    {
+        enum : uint32_t
+        {
+            Multiplier = 0
+        };
+    };
+
+    template <>
     struct MfmaPerfTraits<MI100, bfloat16_t>
     {
         enum : uint32_t
@@ -138,6 +156,15 @@ namespace rocwmma
         enum : uint32_t
         {
             Multiplier = 1024
+        };
+    };
+
+    template <>
+    struct MfmaPerfTraits<MI200, float8_t>
+    {
+        enum : uint32_t
+        {
+            Multiplier = 0
         };
     };
 

--- a/test/performance.hpp
+++ b/test/performance.hpp
@@ -59,6 +59,15 @@ namespace rocwmma
     };
 
     template <>
+    struct MfmaPerfTraits<DefaultArch, bfloat8_t>
+    {
+        enum : uint32_t
+        {
+            Multiplier = 0
+        };
+    };
+
+    template <>
     struct MfmaPerfTraits<DefaultArch, bfloat16_t>
     {
         enum : uint32_t
@@ -114,6 +123,15 @@ namespace rocwmma
     };
 
     template <>
+    struct MfmaPerfTraits<MI100, bfloat8_t>
+    {
+        enum : uint32_t
+        {
+            Multiplier = 0
+        };
+    };
+
+    template <>
     struct MfmaPerfTraits<MI100, bfloat16_t>
     {
         enum : uint32_t
@@ -161,6 +179,15 @@ namespace rocwmma
 
     template <>
     struct MfmaPerfTraits<MI200, float8_t>
+    {
+        enum : uint32_t
+        {
+            Multiplier = 0
+        };
+    };
+
+    template <>
+    struct MfmaPerfTraits<MI200, bfloat8_t>
     {
         enum : uint32_t
         {

--- a/test/unit/unit_kernel_base_impl.hpp
+++ b/test/unit/unit_kernel_base_impl.hpp
@@ -81,7 +81,9 @@ namespace rocwmma
     {
         auto deviceArch = DeviceInfo::instance()->getGcnArch();
         return (deviceArch != DeviceInfo::UNSUPPORTED_ARCH
-                && !(deviceArch == DeviceInfo::GFX908 && std::is_same<DataT, float64_t>::value));
+                && !(deviceArch == DeviceInfo::GFX908 &&
+                    (std::is_same<DataT, float64_t>::value || std::is_same<DataT, float8_t>::value))
+                && !(deviceArch == DeviceInfo::GFX90A && std::is_same<DataT, float8_t>::value));
     }
 
     template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>

--- a/test/unit/unit_kernel_base_impl.hpp
+++ b/test/unit/unit_kernel_base_impl.hpp
@@ -82,8 +82,10 @@ namespace rocwmma
         auto deviceArch = DeviceInfo::instance()->getGcnArch();
         return (deviceArch != DeviceInfo::UNSUPPORTED_ARCH
                 && !(deviceArch == DeviceInfo::GFX908 &&
-                    (std::is_same<DataT, float64_t>::value || std::is_same<DataT, float8_t>::value))
-                && !(deviceArch == DeviceInfo::GFX90A && std::is_same<DataT, float8_t>::value));
+                    (std::is_same<DataT, float64_t>::value || std::is_same<DataT, float8_t>::value
+                    || std::is_same<DataT, bfloat8_t>::value))
+                && !(deviceArch == DeviceInfo::GFX90A &&
+                    (std::is_same<DataT, float8_t>::value || std::is_same<DataT, bfloat8_t>::value)));
     }
 
     template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>

--- a/test/unit/unit_test_params.hpp
+++ b/test/unit/unit_test_params.hpp
@@ -51,7 +51,6 @@ namespace rocwmma
                                         float16_t,
                                         hfloat16_t,
                                         float32_t,
-                                        float8_t,
                                         int8_t,
                                         int32_t
 #ifdef ROCWMMA_EXTENDED_TESTS

--- a/test/unit/unit_test_params.hpp
+++ b/test/unit/unit_test_params.hpp
@@ -51,6 +51,7 @@ namespace rocwmma
                                         float16_t,
                                         hfloat16_t,
                                         float32_t,
+                                        float8_t,
                                         int8_t,
                                         int32_t
 #ifdef ROCWMMA_EXTENDED_TESTS


### PR DESCRIPTION
add checks to allow f8 and bf8 computation on supported devices
enable gemm testing