### PR TITLE
Add Doxygen warnings as errors.

### DIFF
--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -733,6 +733,8 @@ WARNINGS               = YES
 
 WARN_IF_UNDOCUMENTED   = YES
 
+WARN_AS_ERROR          = YES
+
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters
 # in a documented function, or documenting parameters that don't exist or using
@@ -2064,7 +2066,11 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = __device__ ROCWMMA_DEVICE
+PREDEFINED             = "__device__= " \
+                          "ROCWMMA_DEVICE= " \
+                          "__align__(n)= " \
+                          "decltype(auto)= T" \
+                          "ROCWMMA_HOST_DEVICE= " 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/library/include/rocwmma/internal/cross_lane_ops.hpp
+++ b/library/include/rocwmma/internal/cross_lane_ops.hpp
@@ -34,11 +34,13 @@ namespace rocwmma
     namespace CrossLaneOps
     {
         /**
-         * \defgroup Cross-Lane Operations
+         * \defgroup Cross_Lane_Operations Cross-Lane Operations
          *
          * @brief Defines generalized cross-lane operation meta-data and properties.
          * Meta-data is used to provide information and ultimately steer controls
          * implementing the functional backends such as dpp, swizzle or permute.
+         *
+         * @{
          */
 
         enum Properties : uint32_t
@@ -115,6 +117,7 @@ namespace rocwmma
             }
         };
 
+        /** @}*/
     } // namespace CrossLaneOps
 
 } // namespace rocwmma

--- a/library/include/rocwmma/internal/dpp.hpp
+++ b/library/include/rocwmma/internal/dpp.hpp
@@ -35,10 +35,10 @@ namespace rocwmma
     namespace Dpp
     {
         /**
-         * \ingroup Dpp Ops
-         * \defgroup Dpp Front-End
+         * \ingroup Cross_Lane_Operations
          *
          * @brief Cross-lane operations implemented with the amdgcn_mov_dpp backend.
+         * @{
          *
          * This function does not use LDS memory or LDS hardware, therefore does not
          * implicitly require lgkmcnt waits. This is the fastest cross-lane function,
@@ -321,6 +321,7 @@ namespace rocwmma
         using Swap2 = Driver<DppImpl::Ops::Swap2, RowMask, BankMask, BoundCtrl>;
 
         using Nop = MaskMove<>;
+        /** @}*/
 
     } // namespace Dpp
 

--- a/library/include/rocwmma/internal/dpp_impl.hpp
+++ b/library/include/rocwmma/internal/dpp_impl.hpp
@@ -503,8 +503,7 @@ namespace rocwmma
         namespace OpsBase
         {
             /**
-             * \ingroup Cross-Lane Operations
-             * \defgroup Dpp Ops
+             * \ingroup Cross_Lane_Operations
              *
              * @brief Cross-lane operations implemented with the amdgcn_mov_dpp backend.
              * @note In this context:
@@ -517,6 +516,8 @@ namespace rocwmma
              * Here we build out the cross-lane properties specific to DPP, such as the backend (OP_IMPL) and the
              * control code drivers for the backend function call (OP_CTRL). Control code generators are implemented
              * in the DppCtrl namespace.
+             *
+             * @{
              */
 
             template <uint32_t OpId, uint32_t SubGroupSize>
@@ -565,7 +566,7 @@ namespace rocwmma
             };
 
             /*! \class Reverse
-            *  \brief Perform reversal of elements in sub-groups of <SubGroupSize> threads.
+            *  \brief Perform reversal of elements in sub-groups of \p SubGroupSize threads.
             */
 
             template <uint32_t SubGroupSize, class ReverseCtrl>
@@ -575,7 +576,7 @@ namespace rocwmma
             };
 
             /*! \class Rotate
-            *  \brief Perform element-wise rotation in direction <RotateDir> in sub-groups of <SubGroupSize> threads.
+            *  \brief Perform element-wise rotation in direction \p RotateDir in sub-groups of \p SubGroupSize threads.
             *
             * @tparam RotateDir rotation direction: see Properties
             * @tparam RotateDistance element positions to move in specified direction. Positions wrapped by sub group size.
@@ -610,7 +611,7 @@ namespace rocwmma
             using RotateL = Rotate<OP_DIR_L, RotateDistance, SubGroupSize, RotateCtrl>;
 
             /*! \class Shift
-            *  \brief Perform element-wise shift in direction <ShiftDir> in sub-groups of <SubGroupSize> threads.
+            *  \brief Perform element-wise shift in direction \p ShiftDir in sub-groups of \p SubGroupSize threads.
             *
             * @tparam ShiftDir shift direction: see Properties
             * @tparam ShiftDistance element positions to move in specified direction. Positions do not wrap around
@@ -643,7 +644,7 @@ namespace rocwmma
             using ShiftL = Shift<OP_DIR_L, ShiftDistance, SubGroupSize, ShiftCtrl>;
 
             /*! \class Shuffle
-            *  \brief Perform localized shuffling within sub-groups of <SubGroupSize> threads.
+            *  \brief Perform localized shuffling within sub-groups of \p SubGroupSize threads.
             */
             template <uint32_t SubGroupSize, class ShuffleCtrl>
             struct Shuffle : public DppOp<OP_ID_SHUFFLE, SubGroupSize>,
@@ -652,9 +653,9 @@ namespace rocwmma
             };
 
             // Common Shuffle variants
-            /*! \class Shuffle<N>
-            *  \brief Perform localized shuffling within all sub-groups of <N> threads.
-            * <N> = group size.
+            /*! \class Shuffle4
+            *  \brief Shuffle\<N\> Perform localized shuffling within all sub-groups of \em N threads.
+            * \em N = group size.
             *
             * @tparam Select0 - index of element to shuffle to index 0
             * @tparam Select1 - index of element to shuffle to index 1
@@ -715,13 +716,14 @@ namespace rocwmma
             };
 
             /*! \class Swap
-            *  \brief Perform swap of neigbouring sub-groups of <SubGroupSize> threads.
+            *  \brief Perform swap of neigbouring sub-groups of \p SubGroupSize threads.
             */
             template <uint32_t SubGroupSize, class SwapCtrl>
             struct Swap : public DppOp<OP_ID_SWAP, SubGroupSize>,
                           public Backend::amdgcn_mov_dpp<SwapCtrl>
             {
             };
+            /** @}*/
 
         } // namespace OpsBase
 

--- a/library/include/rocwmma/internal/io_config.hpp
+++ b/library/include/rocwmma/internal/io_config.hpp
@@ -39,16 +39,10 @@ namespace rocwmma
 {
 
     /**
- * \ingroup rocwmma
- * \defgroup ROCWMMA IOConfig
- *
- * @brief ROCWMMA fragment input and output configurations leveraging amdgcn architecture
- */
-
-    /**
- * \ingroup ROCWMMA IOConfig
- * @{
- */
+     * \defgroup Rocwmma_ioconf ROCWMMA IOConfig
+     * @brief ROCWMMA fragment input and output configurations leveraging amdgcn architecture
+     * @{
+     */
 
     /*! \struct IOConfig
  *  \brief Definition of ROCWMMA fragment input / output configurations
@@ -134,6 +128,7 @@ namespace rocwmma
         using PackUtil    = PackUtil<DataT>;
         using Broadcaster = Broadcast<DataT, IOTraits::UnpackedSize>;
     };
+    /** @}*/
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/layout.hpp
+++ b/library/include/rocwmma/internal/layout.hpp
@@ -43,10 +43,10 @@ namespace rocwmma
     namespace MatrixLayout
     {
         /**
-         * \ingroup rocwmma
-         * \defgroup Matrix Layouts
+         * \defgroup Matrix_Layouts Matrix Layouts
          *
          * @brief Definition and metadata on supported matrix layouts.
+         * @{
          *
          * These layouts are based in matrix coordinate space. They map each of the wavefront lanes
          * into corresponding (X , Y) = (row,  col) coordinates for a particular memory layout.
@@ -60,11 +60,6 @@ namespace rocwmma
          *
          * - Cumulative offset: the cumulative offset for a particular iteration,
          *   E.g. Sum of incremental offsets for [i = 0, iteration)
-         */
-
-        /**
-         * \ingroup Matrix Layouts
-         * @{
          */
 
         /**
@@ -185,7 +180,6 @@ namespace rocwmma
          *       ...     |   ...    |
          *      RegN*S   |  (N, S)  |
          *       ...     |   ...    |
-         * @}
          */
 
         template <uint32_t BlockDim,
@@ -212,11 +206,6 @@ namespace rocwmma
                               "ColNT in col_major does not support VectorWidth > 1");
             };
         };
-
-        /**
-         * \ingroup Matrix Layouts
-         * @{
-         */
 
         /**
          * RowNT Layout
@@ -315,7 +304,6 @@ namespace rocwmma
          *       ...     |   ...    |
          *      RegN*S   |  (N, S)  |
          *       ...     |   ...    |
-         * @}
          */
         template <uint32_t BlockDim,
                   uint32_t BlockK,
@@ -342,10 +330,6 @@ namespace rocwmma
             };
         };
 
-        /**
-         * \ingroup Matrix Layouts
-         * @{
-         */
         /**
          * Col and Row layouts: unrestricted vector width col and row ordering.
          * Unline their NT cousins, these layouts do not guarantee the same
@@ -391,7 +375,7 @@ namespace rocwmma
          * The column ordering however will be determined as a multiple of MaxVW to
          * fulfill MaxVW priority.
          *
-         *  Data Layout: row_major <same as ColNT>
+         *  Data Layout: row_major \<same as ColNT\>
          *  Register Mapping (BlockDim < 64):
          *
          *      N = Max VectorWidth
@@ -424,7 +408,7 @@ namespace rocwmma
          * across multiple registers. Col ordering still fufills MaxVW
          * priority first.
          *
-         *  Data Layout: row_major <same as ColNT>
+         *  Data Layout: row_major \<same as ColNT\>
          *  Register Mapping (BlockDim == 64):
          *
          *      N = Max Vector Width
@@ -457,7 +441,7 @@ namespace rocwmma
          * to satisfy MaxVW priority before moving on to the next BlockDim
          * segment.
          *
-         *  Data Layout: row_major <same as ColNT>
+         *  Data Layout: row_major \<same as ColNT>
          *  Register Mapping (BlockDim > 64):
          *
          *      Priority 1: Visit MaxVW Segments
@@ -498,7 +482,6 @@ namespace rocwmma
          *   Reg2N-1 | (0, 1, N-1) | (0, 1, 2N-1) | ... | (1, 1, N-1) | ... | (N-1, 1, 64-1)   |
          *   ....    |  ...        |    ...       | ... |   ....      | ... |     ...          |
          *
-         * @}
         */
 
         template <uint32_t BlockDim,
@@ -518,11 +501,6 @@ namespace rocwmma
                 using MatrixCoordT = typename MappingUtil::MatrixCoordT;
             };
         };
-
-        /**
-         * \ingroup Matrix Layouts
-         * @{
-         */
 
         /**
          * Row Layout
@@ -564,7 +542,7 @@ namespace rocwmma
          * The row ordering however will be determined as a multiple of MaxVW to
          * fulfill MaxVW priority.
          *
-         *  Data Layout: col_major <same as RowNT>
+         *  Data Layout: col_major \<same as RowNT\>
          *  Register Mapping (BlockDim < 64):
          *
          *      N = Max VectorWidth
@@ -597,7 +575,7 @@ namespace rocwmma
          * across multiple registers. Row ordering still fufills MaxVW
          * priority first.
          *
-         *  Data Layout: col_major <same as RowNT>
+         *  Data Layout: col_major \<same as RowNT\>
          *  Register Mapping (BlockDim == 64):
          *
          *      N = Max Vector Width
@@ -631,7 +609,7 @@ namespace rocwmma
          * to satisfy MaxVW priority before moving on to the next BlockDim
          * segment.
          *
-         *  Data Layout: col_major <same as RowNT>
+         *  Data Layout: col_major \<same as RowNT\>
          *  Register Mapping (BlockDim > 64):
          *
          *      Priority 1: Visit MaxVW Segments
@@ -671,7 +649,6 @@ namespace rocwmma
          *   ....    |  ...        |    ...       | ... |   ....      | ... |     ...          |
          *   Reg2N-1 | (0, 1, N-1) | (0, 1, 2N-1) | ... | (1, 1, N-1) | ... | (N-1, 1, 64-1)   |
          *   ....    |  ...        |    ...       | ... |   ....      | ... |     ...          |
-         * @}
          */
         template <uint32_t BlockDim,
                   uint32_t BlockK,
@@ -693,6 +670,7 @@ namespace rocwmma
 
         template <typename LayoutT>
         using OrthogonalLayout_t = typename detail::OrthogonalLayout<LayoutT>::Type;
+        /** @}*/
 
     } // namespace MatrixLayout
 

--- a/library/include/rocwmma/internal/permute_impl.hpp
+++ b/library/include/rocwmma/internal/permute_impl.hpp
@@ -235,7 +235,7 @@ namespace rocwmma
             };
 
             /*! \class Rotate
-            *  \brief Perform element-wise rotation in direction <RotateDir> in sub-groups of <SubGroupSize> threads.
+            *  \brief Perform element-wise rotation in direction \p RotateDir in sub-groups of \p SubGroupSize threads.
             *
             * @tparam RotateDir rotation direction: see Properties
             * @tparam RotateDistance element positions to move in specified direction. Positions wrapped by sub group size.
@@ -286,8 +286,7 @@ namespace rocwmma
         namespace Ops
         {
             /**
-             * \ingroup Cross-Lane Operations
-             * \defgroup Permute Ops
+             * \ingroup Cross_Lane_Operations
              *
              * @brief Cross-lane operations implemented with the amdgcn_ds_permute and amdgcn_ds_bpermute backends.
              *

--- a/library/include/rocwmma/internal/swizzle.hpp
+++ b/library/include/rocwmma/internal/swizzle.hpp
@@ -35,8 +35,8 @@ namespace rocwmma
     namespace Swizzle
     {
         /**
-         * \ingroup Swizzle Ops
-         * \defgroup Swizzle Front-End
+         * \ingroup Cross_Lane_Operations
+         * @{
          *
          * @brief Cross-lane operations implemented with the amdgcn_ds_swizzle backend.
          *
@@ -195,6 +195,7 @@ namespace rocwmma
         // Fft variants
         template <uint32_t SubGroupSize, uint32_t FftCtrl>
         using Fft = Driver<SwizzleImpl::Ops::Fft<SubGroupSize, FftCtrl>>;
+        /** @}*/
 
     } // namespace Swizzle
 

--- a/library/include/rocwmma/internal/swizzle_impl.hpp
+++ b/library/include/rocwmma/internal/swizzle_impl.hpp
@@ -234,7 +234,7 @@ namespace rocwmma
             };
 
             /*! \class Reverse
-            *  \brief Perform reversal of elements in sub-groups of <SubGroupSize> threads.
+            *  \brief Perform reversal of elements in sub-groups of \p SubGroupSize threads.
             */
             template <uint32_t SubGroupSize>
             struct Reverse : public SwzOp<OP_ID_REVERSE, SubGroupSize>,
@@ -243,7 +243,7 @@ namespace rocwmma
             };
 
             /*! \class Rotate
-            *  \brief Perform element-wise rotation in direction <RotateDir> in sub-groups of <SubGroupSize> threads.
+            *  \brief Perform element-wise rotation in direction \p RotateDir in sub-groups of \p SubGroupSize threads.
             *
             * @tparam RotateDir rotation direction: see Properties
             * @tparam RotateDistance element positions to move in specified direction. Positions wrapped by sub group size.
@@ -276,7 +276,7 @@ namespace rocwmma
             using RotateL = Rotate<OP_DIR_L, RotateDistance, SubGroupSize>;
 
             /*! \class Shuffle
-            *  \brief Perform localized shuffling within sub-groups of <SubGroupSize> threads.
+            *  \brief Perform localized shuffling within sub-groups of \p SubGroupSize threads.
             */
             template <uint32_t SubGroupSize, class ShuffleCtrl>
             struct Shuffle : public SwzOp<OP_ID_SHUFFLE, SubGroupSize>,
@@ -285,9 +285,9 @@ namespace rocwmma
             };
 
             // Common Shuffle variants
-            /*! \class Shuffle<N>
-            *  \brief Perform localized shuffling within all sub-groups of <N> threads.
-            * <N> = group size.
+            /*! \class Shuffle4
+            *  \brief Shuffle\<N\> Perform localized shuffling within all sub-groups of \em N threads.
+            * \em N = group size.
             *
             * @tparam Select0 - index of element to shuffle to index 0
             * @tparam Select1 - index of element to shuffle to index 1
@@ -348,7 +348,7 @@ namespace rocwmma
             };
 
             /*! \class Swap
-            *  \brief Perform swap of neigbouring sub-groups of <SubGroupSize> threads.
+            *  \brief Perform swap of neigbouring sub-groups of \p SubGroupSize threads.
             */
             template <uint32_t SubGroupSize>
             struct Swap : public SwzOp<OP_ID_SWAP, SubGroupSize>,
@@ -362,10 +362,10 @@ namespace rocwmma
         {
 
             /**
-             * \ingroup Cross-Lane Operations
-             * \defgroup Swizzle Ops
+             * \ingroup Cross_Lane_Operations
              *
              * @brief Cross-lane operations implemented with the amdgcn_ds_swizzle backend.
+             * @{
              */
 
             // clang-format off
@@ -452,6 +452,7 @@ namespace rocwmma
             */
             template <uint32_t SubGroupSize, uint32_t FftCtrl>
             using Fft = OpsBase::Fft<SubGroupSize, FftCtrl>;
+            /** @}*/
 
             // clang-format on
         } // namespace Ops

--- a/library/include/rocwmma/internal/type_traits.hpp
+++ b/library/include/rocwmma/internal/type_traits.hpp
@@ -413,6 +413,7 @@ namespace std
     ///////////  std::numeric_limits<float16_t>  //////////////
     ///////////////////////////////////////////////////////////
 
+    // @cond
     template <>
     ROCWMMA_HOST_DEVICE constexpr rocwmma::float16_t
         numeric_limits<rocwmma::float16_t>::epsilon() noexcept
@@ -588,6 +589,7 @@ namespace std
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7FC0));
         return eps.b16;
     }
+    // @endcond
 
 } // namespace std
 

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -41,10 +41,11 @@ namespace rocwmma
 {
 
     /**
- * \ingroup rocwmma
- * \defgroup DataTypes
+ * \defgroup DataTypes Data Type Metadata
  *
  * @brief Definition and metadata on supported data types of matrices.
+ *
+ * @{
  *
  * Native Data Types:
  * float64_t = f64 = double
@@ -124,6 +125,7 @@ namespace rocwmma
         mem_row_major,
         mem_col_major
     };
+    /** @}*/
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/vector_impl.hpp
+++ b/library/include/rocwmma/internal/vector_impl.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -459,6 +459,7 @@ namespace rocwmma
         return detail::unOp<detail::ArithmeticOp::Minus>(*this, detail::Seq<Rank>{});
     }
 
+    // @cond
     template <typename T, unsigned int Rank>
     template <typename U, typename std::enable_if<std::is_integral<U>{}>::type*>
     ROCWMMA_HOST_DEVICE inline auto
@@ -466,6 +467,7 @@ namespace rocwmma
     {
         return (*this = detail::binOp<detail::BitwiseOp::And>(*this, x_, detail::Seq<Rank>{}));
     }
+    // @endcond
 
     template <typename T, unsigned int Rank>
     template <typename U, typename std::enable_if<std::is_integral<U>{}>::type*>

--- a/library/include/rocwmma/rocwmma.hpp
+++ b/library/include/rocwmma/rocwmma.hpp
@@ -180,10 +180,10 @@ namespace rocwmma
     using io_config = rocwmma::IOConfig<MatrixT, BlockM, BlockN, BlockK, DataT, DataLayout>;
 
     /**
- * \ingroup rocwmma
- * \defgroup ROCWMMA APIs
+ * \defgroup Rocwmma ROCWMMA Public API
  *
  * @brief ROCWMMA Fragment and its API function definitions.
+ * @{
  */
 
     /*! \class fragment
@@ -388,6 +388,7 @@ namespace rocwmma
     //! Synchronization point for all wavefronts in a workgroup.
     ROCWMMA_DEVICE void synchronize_workgroup();
 
+    /** @}*/
 } // namespace rocwmma
 
 #include "rocwmma_impl.hpp"

--- a/library/include/rocwmma/rocwmma_coop.hpp
+++ b/library/include/rocwmma/rocwmma_coop.hpp
@@ -29,8 +29,6 @@
 #include "rocwmma.hpp"
 
 /**
- * \mainpage
- *
  * ROCWMMACoop complements the ROCWMMA API with support for cooperative operations.
  * Operations may be split into smaller unit work items that are assigned to waves
  * in a collaborative pool using a round-robin fashion.


### PR DESCRIPTION
Set WARN_AS_ERROR=YES and Doxygen will stop if there is a warning.

Fix some issues that caused Doxygen warnings.

- Add new Doxygen PREDEFINED
- Clean up Groups
- Escape '<' and '>'