### PR TITLE
Adjust build and run predicates

### DIFF
--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/device/kernel_predicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,14 +62,26 @@ namespace rocwmma
             CostCTest = ((uint32_t)TestTraits::Cost::TileC <= 256u),
             CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
-            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
-                         (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value
-                         || std::is_same<InputT, bfloat8_t>::value) &&
-                         (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
-                         (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
+            // Gfx940 arch req'd for float8_t, bfloat8_t and xfloat32_t
+            TypesTest
+            = !(std::is_same<InputT, float8_t>::value || std::is_same<InputT, bfloat8_t>::value
+                || std::is_same<InputT, xfloat32_t>::value)
+              || (bool)TestTraits::Arch::IsGfx940,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64
-                      && CostABTest && CostCTest && CostDTest && BlockKTest)
+            // BlockK minimums for certain data types to run.
+            // The following conditions must be met:
+            // - Gfx940 [int8_t] BlockM/N_16 : BlockK >= 32
+            // - Gfx940 [int8_t] BlockM/N_32 : BlockK >= 16
+            // - [float8_t, bfloat8_t] BlockM/N_16 : BlockK >= 32
+            // - [float8_t, bfloat8_t] BlockM/N_32 : BlockK >= 16
+            BlockKTest
+            = !(((bool)TestTraits::Arch::IsGfx940 && std::is_same<InputT, int8_t>::value)
+                || std::is_same<InputT, float8_t>::value || std::is_same<InputT, bfloat8_t>::value)
+              || (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u))
+              || (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u)),
+
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && CostABTest
+                      && CostCTest && CostDTest && TypesTest && BlockKTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_SB_NC/device/kernel_predicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,14 +61,26 @@ namespace rocwmma
             CostCTest = ((uint32_t)TestTraits::Cost::TileC <= 256u),
             CostDTest = ((uint32_t)TestTraits::Cost::TileD <= 256u),
 
-            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
-                        (std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value
-                        || std::is_same<InputT, bfloat8_t>::value) &&
-                        (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
-                        (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
+            // Gfx940 arch req'd for float8_t, bfloat8_t and xfloat32_t
+            TypesTest
+            = !(std::is_same<InputT, float8_t>::value || std::is_same<InputT, bfloat8_t>::value
+                || std::is_same<InputT, xfloat32_t>::value)
+              || (bool)TestTraits::Arch::IsGfx940,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64
-                      && CostABTest && CostCTest && CostDTest && BlockKTest)
+            // BlockK minimums for certain data types to run.
+            // The following conditions must be met:
+            // - Gfx940 [int8_t] BlockM/N_16 : BlockK >= 32
+            // - Gfx940 [int8_t] BlockM/N_32 : BlockK >= 16
+            // - [float8_t, bfloat8_t] BlockM/N_16 : BlockK >= 32
+            // - [float8_t, bfloat8_t] BlockM/N_32 : BlockK >= 16
+            BlockKTest
+            = !(((bool)TestTraits::Arch::IsGfx940 && std::is_same<InputT, int8_t>::value)
+                || std::is_same<InputT, float8_t>::value || std::is_same<InputT, bfloat8_t>::value)
+              || (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u))
+              || (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u)),
+
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && CostABTest
+                      && CostCTest && CostDTest && TypesTest && BlockKTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,14 +81,26 @@ namespace rocwmma
                              + 2u * (uint32_t)TestTraits::Cost::TileD)
                             <= 256u),
 
-            BlockKTest = ((bool)TestTraits::Arch::IsGfx940 &&
-                        ( std::is_same<InputT, int8_t>::value || std::is_same<InputT, float8_t>::value
-                        || std::is_same<InputT, bfloat8_t>::value) &&
-                        (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u)) ||
-                        (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u))),
+            // Gfx940 arch req'd for float8_t, bfloat8_t and xfloat32_t
+            TypesTest
+            = !(std::is_same<InputT, float8_t>::value || std::is_same<InputT, bfloat8_t>::value
+                || std::is_same<InputT, xfloat32_t>::value)
+              || (bool)TestTraits::Arch::IsGfx940,
 
-            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64
-                      && CostABTest && CostAccTest && CostTailTest && BlockKTest)
+            // BlockK minimums for certain data types to run.
+            // The following conditions must be met:
+            // - Gfx940 [int8_t] BlockM/N_16 : BlockK >= 32
+            // - Gfx940 [int8_t] BlockM/N_32 : BlockK >= 16
+            // - [float8_t, bfloat8_t] BlockM/N_16 : BlockK >= 32
+            // - [float8_t, bfloat8_t] BlockM/N_32 : BlockK >= 16
+            BlockKTest
+            = !(((bool)TestTraits::Arch::IsGfx940 && std::is_same<InputT, int8_t>::value)
+                || std::is_same<InputT, float8_t>::value || std::is_same<InputT, bfloat8_t>::value)
+              || (((BlockM == 16u) || (BlockN == 16u)) && (BlockK >= 32u))
+              || (((BlockM == 32u) || (BlockN == 32u)) && (BlockK >= 16u)),
+
+            Enable = ((bool)TestTraits::IsGfx9 && (bool)TestTraits::IsWave64 && CostABTest
+                      && CostAccTest && CostTailTest && TypesTest && BlockKTest)
         };
 
         enum struct Gfx11Predicates : bool

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -630,16 +630,16 @@ namespace rocwmma
                 CHECK_HIP_ERROR(hipEventElapsedTime(&timeMs, startEvent, stopEvent));
 
                 // Calculate efficiency
-                auto& deviceInfo             = DeviceInfo::instance();
+                auto& deviceInfo = DeviceInfo::instance();
 
-                auto  devicePeakGFlopsPerSec  = deviceInfo->peakGFlopsPerSec<InputT>();
+                auto devicePeakGFlopsPerSec = deviceInfo->peakGFlopsPerSec<InputT>();
 
                 mElapsedTimeMs        = float64_t(timeMs);
                 mTotalGFlops          = calculateGFlops(mM, mN, mK);
                 mMeasuredTFlopsPerSec = calculateTFlopsPerSec(mM, mN, mK, mElapsedTimeMs)
                                         * static_cast<float64_t>(mRepeats);
 
-                mEfficiency = round(mMeasuredTFlopsPerSec / devicePeakGFlopsPerSec  * 100000.0);
+                mEfficiency = round(mMeasuredTFlopsPerSec / devicePeakGFlopsPerSec * 100000.0);
 
                 CHECK_HIP_ERROR(hipEventDestroy(startEvent));
                 CHECK_HIP_ERROR(hipEventDestroy(stopEvent));
@@ -667,64 +667,67 @@ namespace rocwmma
             auto rocBlasKernel = [this, &handle]() {
                 auto& dataInstance = DataStorage::instance();
 
-                if((std::is_same<InputT, float8_t>::value) || (std::is_same<InputT, bfloat8_t>::value))
+                if constexpr((std::is_same<InputT, float8_t>::value)
+                             || (std::is_same<InputT, bfloat8_t>::value))
                 {
 #if defined(ROCBLAS_DATA_TYPE_FLOAT8)
                     {
-                    rocblas_computetype computeType = rocblas_compute_type_f32;
-                    CHECK_ROCBLAS_ERROR(rocblas_gemm_ex3(handle,
-                                                         rocblas_layout<LayoutA>::operation(), // opA
-                                                         rocblas_layout<LayoutB>::operation(), // opB
-                                                         this->mM, // M
-                                                         this->mN, // N
-                                                         this->mK, // K
-                                                         &(this->mAlpha), // alpha,
-                                                         dataInstance->deviceA().get(), // A*,
-                                                         rocblas_types<InputT>::type(), // a_type
-                                                         this->mLda, // lda
-                                                         dataInstance->deviceB().get(), // B*,
-                                                         rocblas_types<InputT>::type(), // b_type
-                                                         this->mLdb, // ldb
-                                                         &(this->mBeta), // beta
-                                                         dataInstance->deviceC().get(), // C*
-                                                         rocblas_types<OutputT>::type(), // c_type
-                                                         this->mM, // ldc (col major output only)
-                                                         dataInstance->deviceD().get(), // D*
-                                                         rocblas_types<OutputT>::type(), // d_type
-                                                         this->mM, // ldd (col major output only)
-                                                         computeType, // compute_type
-                                                         rocblas_gemm_algo_standard, // algo
-                                                         0, // solution_index
-                                                         0)); // flags
+                        rocblas_computetype computeType = rocblas_compute_type_f32;
+                        CHECK_ROCBLAS_ERROR(
+                            rocblas_gemm_ex3(handle,
+                                             rocblas_layout<LayoutA>::operation(), // opA
+                                             rocblas_layout<LayoutB>::operation(), // opB
+                                             this->mM, // M
+                                             this->mN, // N
+                                             this->mK, // K
+                                             &(this->mAlpha), // alpha,
+                                             dataInstance->deviceA().get(), // A*,
+                                             rocblas_types<InputT>::type(), // a_type
+                                             this->mLda, // lda
+                                             dataInstance->deviceB().get(), // B*,
+                                             rocblas_types<InputT>::type(), // b_type
+                                             this->mLdb, // ldb
+                                             &(this->mBeta), // beta
+                                             dataInstance->deviceC().get(), // C*
+                                             rocblas_types<OutputT>::type(), // c_type
+                                             this->mM, // ldc (col major output only)
+                                             dataInstance->deviceD().get(), // D*
+                                             rocblas_types<OutputT>::type(), // d_type
+                                             this->mM, // ldd (col major output only)
+                                             computeType, // compute_type
+                                             rocblas_gemm_algo_standard, // algo
+                                             0, // solution_index
+                                             0)); // flags
                     }
 #endif
                 }
                 else
                 {
-                    CHECK_ROCBLAS_ERROR(rocblas_gemm_ex(handle,
-                                                        rocblas_layout<LayoutA>::operation(), // opA
-                                                        rocblas_layout<LayoutB>::operation(), // opB
-                                                        this->mM, // M
-                                                        this->mN, // N
-                                                        this->mK, // K
-                                                        &(this->mAlpha), // alpha,
-                                                        dataInstance->deviceA().get(), // A*,
-                                                        rocblas_types<InputT>::type(), // a_type
-                                                        this->mLda, // lda
-                                                        dataInstance->deviceB().get(), // B*,
-                                                        rocblas_types<InputT>::type(), // b_type
-                                                        this->mLdb, // ldb
-                                                        &(this->mBeta), // beta
-                                                        dataInstance->deviceC().get(), // C*
-                                                        rocblas_types<OutputT>::type(), // c_type
-                                                        this->mM, // ldc (col major output only)
-                                                        dataInstance->deviceD().get(), // D*
-                                                        rocblas_types<OutputT>::type(), // d_type
-                                                        this->mM, // ldd (col major output only)
-                                                        rocblas_types<ComputeT>::type(), // compute_type
-                                                        rocblas_gemm_algo_standard, // algo
-                                                        0, // solution_index
-                                                        0)); // flags
+                    CHECK_ROCBLAS_ERROR(
+                        rocblas_gemm_ex(handle,
+                                        rocblas_layout<LayoutA>::operation(), // opA
+                                        rocblas_layout<LayoutB>::operation(), // opB
+                                        this->mM, // M
+                                        this->mN, // N
+                                        this->mK, // K
+                                        &(this->mAlpha), // alpha,
+                                        dataInstance->deviceA().get(), // A*,
+                                        rocblas_types<InputT>::type(), // a_type
+                                        this->mLda, // lda
+                                        dataInstance->deviceB().get(), // B*,
+                                        rocblas_types<InputT>::type(), // b_type
+                                        this->mLdb, // ldb
+                                        &(this->mBeta), // beta
+                                        dataInstance->deviceC().get(), // C*
+                                        rocblas_types<OutputT>::type(), // c_type
+                                        this->mM, // ldc (col major output only)
+                                        dataInstance->deviceD().get(), // D*
+                                        rocblas_types<OutputT>::type(), // d_type
+                                        this->mM, // ldd (col major output only)
+                                        rocblas_types<ComputeT>::type(), // compute_type
+                                        rocblas_gemm_algo_standard, // algo
+                                        0, // solution_index
+                                        0)); // flags
                 }
             };
             if(quirks::rocblas_supported<InputT, OutputT, ComputeT>::value)
@@ -806,13 +809,13 @@ namespace rocwmma
                 {
                     // Calculate GPU efficiency
                     auto& deviceInfo             = DeviceInfo::instance();
-                    auto  devicePeakGFlopsPerSec  = deviceInfo->peakGFlopsPerSec<InputT>();
+                    auto  devicePeakGFlopsPerSec = deviceInfo->peakGFlopsPerSec<InputT>();
 
                     auto elapsedTimeMs        = float64_t(timeMs);
                     auto measuredTFlopsPerSec = calculateTFlopsPerSec(mM, mN, mK, elapsedTimeMs)
                                                 * static_cast<float64_t>(mRepeats);
                     mReferenceEfficiency
-                        = round(measuredTFlopsPerSec / devicePeakGFlopsPerSec  * 100000.0);
+                        = round(measuredTFlopsPerSec / devicePeakGFlopsPerSec * 100000.0);
                 }
 
                 CHECK_HIP_ERROR(hipEventDestroy(startEvent));


### PR DESCRIPTION
- Fixes CI on gfx908 and gfx90a
- Restrict gemm tests in float8_t, bfloat8_t and xfloat32_t to gfx940