### PR TITLE
Use system integral types

### DIFF
--- a/library/include/rocwmma/internal/type_traits.hpp
+++ b/library/include/rocwmma/internal/type_traits.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,8 @@
 #ifndef ROCWMMA_TYPE_TRAITS_HPP
 #define ROCWMMA_TYPE_TRAITS_HPP
 
+#include <cfloat>
+
 #include "types.hpp"
 
 namespace rocwmma
@@ -37,9 +39,9 @@ namespace rocwmma
         {
             union
             {
-                uint8_t     i8;
-                float8_t    f8;
-                bfloat8_t   bf8;
+                uint8_t   i8;
+                float8_t  f8;
+                bfloat8_t bf8;
             };
             constexpr Fp8Bits(uint8_t initVal)
                 : i8(initVal)
@@ -59,10 +61,10 @@ namespace rocwmma
         {
             union
             {
-                uint16_t      i16;
-                float16_t     f16;
-                hfloat16_t    h16;
-                bfloat16_t    b16;
+                uint16_t   i16;
+                float16_t  f16;
+                hfloat16_t h16;
+                bfloat16_t b16;
             };
             constexpr Fp16Bits(uint16_t initVal)
                 : i16(initVal)
@@ -86,9 +88,9 @@ namespace rocwmma
         {
             union
             {
-                uint32_t      i32;
-                float32_t     f32;
-                xfloat32_t    xf32;
+                uint32_t   i32;
+                float32_t  f32;
+                xfloat32_t xf32;
             };
             constexpr Fp32Bits(uint32_t initVal)
                 : i32(initVal)

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 #include <hip/hip_fp16.h>
 #include <hip/hip_vector_types.h>
 #include <type_traits>
-#include <cfloat>
 #include <utility>
 #endif // !__HIPCC_RTC__
 
@@ -71,14 +70,14 @@ namespace rocwmma
     using float16_t = _Float16;
     using float32_t = float;
     using float64_t = double;
-    using int8_t    = signed char;
-    using uint8_t   = unsigned char;
-    using int16_t   = short;
-    using uint16_t  = unsigned short;
-    using int32_t   = int;
-    using uint32_t  = unsigned int;
+    using int8_t    = ::int8_t;
+    using uint8_t   = ::uint8_t;
+    using int16_t   = ::int16_t;
+    using uint16_t  = ::uint16_t;
+    using int32_t   = ::int32_t;
+    using uint32_t  = ::uint32_t;
     using int64_t   = ::int64_t;
-    using uint64_t  = unsigned long long int;
+    using uint64_t  = ::uint64_t;
     using index_t   = int32_t;
 
 // Non-native types
@@ -93,7 +92,7 @@ namespace rocwmma
     using hfloat16_t = __half;
 
     using bfloat8_t = rocwmma_bf8;
-    using float8_t = rocwmma_f8;
+    using float8_t  = rocwmma_f8;
 
     using xfloat32_t = rocwmma_xfloat32;
 

--- a/test/hip_resource.hpp
+++ b/test/hip_resource.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@
 #define ROCWMMA_HIP_RESOURCE_HPP
 
 #include <memory>
+#include <rocwmma/internal/types.hpp>
 
 // The HipResource class is intended as a wrapper for allocation, deletion and copying
 // between host and device resources using the HIP backend.


### PR DESCRIPTION
- Uses system integral types
- linux uses (un)signed long as (u)int64_t
- Windows uses (un)signed long long as (u)int64_t
- Standardize under ::(u)int64_t