### PR TITLE
Sample GFX Arch Detection

### DIFF
--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -71,8 +71,10 @@ bool isGfx9()
     std::string deviceName(mProps.gcnArchName);
 
     return ((deviceName.find("gfx908") != std::string::npos)
-        || (deviceName.find("gfx90a") != std::string::npos)
-        || (deviceName.find("gfx940") != std::string::npos));
+            || (deviceName.find("gfx90a") != std::string::npos)
+            || (deviceName.find("gfx940") != std::string::npos)
+            || (deviceName.find("gfx941") != std::string::npos)
+            || (deviceName.find("gfx942") != std::string::npos));
 }
 
 bool isGfx11()
@@ -86,8 +88,8 @@ bool isGfx11()
     std::string deviceName(mProps.gcnArchName);
 
     return ((deviceName.find("gfx1100") != std::string::npos)
-        || (deviceName.find("gfx1101") != std::string::npos)
-        || (deviceName.find("gfx1102") != std::string::npos));
+            || (deviceName.find("gfx1101") != std::string::npos)
+            || (deviceName.find("gfx1102") != std::string::npos));
 }
 
 // HIP Host function to find if the device supports f64
@@ -101,7 +103,10 @@ bool isF64Supported()
 
     std::string deviceName(mProps.gcnArchName);
 
-    return (deviceName.find("gfx90a") != std::string::npos);
+    return ((deviceName.find("gfx90a") != std::string::npos)
+            || (deviceName.find("gfx940") != std::string::npos)
+            || (deviceName.find("gfx941") != std::string::npos)
+            || (deviceName.find("gfx942") != std::string::npos));
 }
 
 bool isF32Supported()

--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -59,6 +59,37 @@
     }
 #endif
 
+// HIP Host functions to determine the gfx architecture
+bool isGfx9()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return ((deviceName.find("gfx908") != std::string::npos)
+        || (deviceName.find("gfx90a") != std::string::npos)
+        || (deviceName.find("gfx940") != std::string::npos));
+}
+
+bool isGfx11()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
+    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return ((deviceName.find("gfx1100") != std::string::npos)
+        || (deviceName.find("gfx1101") != std::string::npos)
+        || (deviceName.find("gfx1102") != std::string::npos));
+}
+
 // HIP Host function to find if the device supports f64
 bool isF64Supported()
 {
@@ -75,16 +106,7 @@ bool isF64Supported()
 
 bool isF32Supported()
 {
-    hipDevice_t     mHandle;
-    hipDeviceProp_t mProps;
-
-    CHECK_HIP_ERROR(hipGetDevice(&mHandle));
-    CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
-
-    std::string deviceName(mProps.gcnArchName);
-
-    return (deviceName.find("gfx908") != std::string::npos)
-           || (deviceName.find("gfx90a") != std::string::npos);
+    return isGfx9();
 }
 
 inline double calculateGFlops(uint32_t m, uint32_t n, uint32_t k)

--- a/samples/perf_dgemm.cpp
+++ b/samples/perf_dgemm.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -666,6 +666,25 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
     auto warpSize = getWarpSize();
     auto macroTileSize
         = rocwmma::make_coord2d(TBLOCK_X / warpSize * WARP_TILE_X, TBLOCK_Y * WARP_TILE_Y);
+
+    // Device check for supported block and wave sizes
+    if(isGfx11())
+    {
+        std::cout << "Unsupported architecture!\n";
+        return;
+    }
+
+    if(isGfx9() && (ROCWMMA_M != 16 || ROCWMMA_N != 16))
+    {
+        std::cout << "Unsupported block size!\n";
+        return;
+    }
+
+    if(isGfx9() && WARP_SIZE != Constants::AMDGCN_WAVE_SIZE_64)
+    {
+        std::cout << "Unsupported wave size!\n";
+        return;
+    }
 
     // Bounds check
     if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < ROCWMMA_K)

--- a/samples/perf_dgemm.cpp
+++ b/samples/perf_dgemm.cpp
@@ -671,7 +671,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
     if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < ROCWMMA_K)
        || (m % ROCWMMA_M || n % ROCWMMA_N || k % ROCWMMA_K))
     {
-        std::cout << "Unsupported size!\n";
+        std::cout << "Unsupported matrix size!\n";
         return;
     }
 

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -701,13 +701,13 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
         return;
     }
 
-    if(isGfx11() && WAVE_SIZE != Constants::AMDGCN_WAVE_SIZE_32)
+    if(isGfx11() && WARP_SIZE != Constants::AMDGCN_WAVE_SIZE_32)
     {
         std::cout << "Unsupported wave size!\n";
         return;
     }
 
-    if(isGfx9() && WAVE_SIZE != Constants::AMDGCN_WAVE_SIZE_64)
+    if(isGfx9() && WARP_SIZE != Constants::AMDGCN_WAVE_SIZE_64)
     {
         std::cout << "Unsupported wave size!\n";
         return;

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -695,7 +695,13 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
         = rocwmma::make_coord2d(TBLOCK_X / warpSize * WARP_TILE_X, TBLOCK_Y * WARP_TILE_Y);
 
     // Device check for supported block and wave sizes
-    if(isGfx11() && (ROCWMMA_M > 16 || ROCWMMA_N > 16))
+    if(isGfx11() && (ROCWMMA_M != 16 || ROCWMMA_N != 16))
+    {
+        std::cout << "Unsupported block size!\n";
+        return;
+    }
+
+    if(isGfx9() && (ROCWMMA_M != ROCWMMA_N) || (ROCWMMA_M != 16 && ROCWMMA_M != 32))
     {
         std::cout << "Unsupported block size!\n";
         return;
@@ -862,19 +868,19 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
 
     // Setup and run reference computation
     std::vector<OutputT> matrixD_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
-    gemm_cpu_h<InputT, OutputT, ComputeT, col_major, row_major, col_major>(m,
-                                                                           n,
-                                                                           k,
-                                                                           matrixA.data(),
-                                                                           matrixB.data(),
-                                                                           matrixC.data(),
-                                                                           matrixD_ref.data(),
-                                                                           lda,
-                                                                           ldb,
-                                                                           ldc,
-                                                                           ldd,
-                                                                           alpha,
-                                                                           beta);
+    gemm_cpu_h<InputT, OutputT, ComputeT, DataLayoutA, DataLayoutB, DataLayoutC>(m,
+                                                                                 n,
+                                                                                 k,
+                                                                                 matrixA.data(),
+                                                                                 matrixB.data(),
+                                                                                 matrixC.data(),
+                                                                                 matrixD_ref.data(),
+                                                                                 lda,
+                                                                                 ldb,
+                                                                                 ldc,
+                                                                                 ldd,
+                                                                                 alpha,
+                                                                                 beta);
 
     auto res = compareEqual(matrixD.data(), matrixD_ref.data(), m * n);
 

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -671,7 +671,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < ROCWMMA_K)
        || (m % ROCWMMA_M || n % ROCWMMA_N || k % ROCWMMA_K))
     {
-        std::cout << "Unsupported size!\n";
+        std::cout << "Unsupported matrix size!\n";
         return;
     }
 

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -666,6 +666,25 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     auto warpSize = getWarpSize();
     auto macroTileSize
         = rocwmma::make_coord2d(TBLOCK_X / warpSize * WARP_TILE_X, TBLOCK_Y * WARP_TILE_Y);
+
+    // Device check for supported block and wave sizes
+    if(isGfx11())
+    {
+        std::cout << "Unsupported architecture!\n";
+        return;
+    }
+
+    if(isGfx9() && (ROCWMMA_M != ROCWMMA_N) || (ROCWMMA_M != 16 && ROCWMMA_M != 32))
+    {
+        std::cout << "Unsupported block size!\n";
+        return;
+    }
+
+    if(isGfx9() && WARP_SIZE != Constants::AMDGCN_WAVE_SIZE_64)
+    {
+        std::cout << "Unsupported wave size!\n";
+        return;
+    }
 
     // Bounds check
     if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < ROCWMMA_K)


### PR DESCRIPTION
Detect the GFX architecture when running samples supported across multiple architectures.
- Default to using parameters beneficial to GFX11 on perf_hgemm
- Add wave and block size checks to perf_hgemm