### PR TITLE
hipRTC fixes (develop)

### DIFF
--- a/library/include/rocwmma/internal/config.hpp
+++ b/library/include/rocwmma/internal/config.hpp
@@ -159,11 +159,7 @@ namespace rocwmma
 ///
 #define ROCWMMA_DEVICE __device__
 
-#if !defined(__HIPCC_RTC__)
 #define ROCWMMA_HOST __host__
-#else
-#define ROCWMMA_HOST
-#endif
 
 #define ROCWMMA_HOST_DEVICE ROCWMMA_HOST ROCWMMA_DEVICE
 

--- a/library/include/rocwmma/internal/float8.h
+++ b/library/include/rocwmma/internal/float8.h
@@ -27,7 +27,20 @@
 #ifndef ROCWMMA_FLOAT8_H
 #define ROCWMMA_FLOAT8_H
 
-#include "types.hpp"
+#include "config.hpp"
+
+#if defined(__HIPCC_RTC__)
+
+using uint8_t = __hip_internal::uint8_t;
+using uint16_t = __hip_internal::uint16_t;
+
+namespace std
+{
+    template <bool B, class T, class F>
+    struct conditional;
+}
+
+#endif
 
 // We are clipping in down conversion by default
 #define rocwmma_F8_downcast_clipping 1
@@ -450,19 +463,19 @@ struct rocwmma_bf8
 
 namespace std
 {
-    inline rocwmma_f8 sin(rocwmma_f8 a)
+    ROCWMMA_HOST_DEVICE inline rocwmma_f8 sin(rocwmma_f8 a)
     {
         return rocwmma_f8(sinf(float(a)));
     }
-    inline rocwmma_f8 cos(rocwmma_f8 a)
+    ROCWMMA_HOST_DEVICE inline rocwmma_f8 cos(rocwmma_f8 a)
     {
         return rocwmma_f8(cosf(float(a)));
     }
-    inline rocwmma_bf8 sin(rocwmma_bf8 a)
+    ROCWMMA_HOST_DEVICE inline rocwmma_bf8 sin(rocwmma_bf8 a)
     {
         return rocwmma_bf8(sinf(float(a)));
     }
-    inline rocwmma_bf8 cos(rocwmma_bf8 a)
+    ROCWMMA_HOST_DEVICE inline rocwmma_bf8 cos(rocwmma_bf8 a)
     {
         return rocwmma_bf8(cosf(float(a)));
     }
@@ -476,6 +489,8 @@ namespace std
     }
 }
 
+#if !defined(__HIPCC_RTC__)
+
 // Special operator overloading
 inline std::ostream& operator<<(std::ostream& os, const rocwmma_f8& f8)
 {
@@ -486,6 +501,8 @@ inline std::ostream& operator<<(std::ostream& os, const rocwmma_bf8& bf8)
 {
     return os << float(bf8);
 }
+
+#endif // !defined(__HIPCC_RTC__)
 
 // all + operator overloading with mixed types
 // mixed types, always converts to f32, does computation in f32, and returns float

--- a/library/include/rocwmma/internal/rocwmma_xfloat32.hpp
+++ b/library/include/rocwmma/internal/rocwmma_xfloat32.hpp
@@ -40,12 +40,26 @@ typedef struct
 
 #else // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
 
+#if !defined(__HIPCC_RTC__)
+
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <hip/hip_runtime.h>
 #include <ostream>
 #include <type_traits>
+
+#else
+
+namespace std
+{
+    using __hip_internal::is_standard_layout;
+    using __hip_internal::is_trivial;
+}
+
+#endif // !defined(__HIPCC_RTC__)
+
+#include "config.hpp"
 
 struct rocwmma_xfloat32
 {
@@ -173,14 +187,18 @@ static_assert(std::is_trivial<rocwmma_xfloat32>{},
               "rocwmma_xfloat32 is not a trivial type, and thus is "
               "incompatible with C.");
 
+#if !defined(__HIPCC_RTC__)
 static_assert(sizeof(rocwmma_xfloat32) == sizeof(rocwmma_xfloat32_public)
                   && offsetof(rocwmma_xfloat32, data) == offsetof(rocwmma_xfloat32_public, data),
               "internal rocwmma_xfloat32 does not match public rocwmma_xfloat32");
+#endif // !defined(__HIPCC_RTC__)
 
+#if !defined(__HIPCC_RTC__)
 inline std::ostream& operator<<(std::ostream& os, const rocwmma_xfloat32& xf32)
 {
     return os << float(xf32);
 }
+#endif // !defined(__HIPCC_RTC__)
 inline ROCWMMA_HOST_DEVICE rocwmma_xfloat32 operator+(rocwmma_xfloat32 a)
 {
     return a;
@@ -301,14 +319,16 @@ namespace std
         } u = {a.data};
         return (u.fp32 == 0.0f);
     }
-    inline rocwmma_xfloat32 sin(rocwmma_xfloat32 a)
+
+    ROCWMMA_HOST_DEVICE inline rocwmma_xfloat32 sin(rocwmma_xfloat32 a)
     {
         return rocwmma_xfloat32(sinf(float(a)));
     }
-    inline rocwmma_xfloat32 cos(rocwmma_xfloat32 a)
+    ROCWMMA_HOST_DEVICE inline rocwmma_xfloat32 cos(rocwmma_xfloat32 a)
     {
         return rocwmma_xfloat32(cosf(float(a)));
     }
+
     ROCWMMA_HOST_DEVICE constexpr rocwmma_xfloat32 real(const rocwmma_xfloat32& a)
     {
         return a;

--- a/library/include/rocwmma/internal/type_traits.hpp
+++ b/library/include/rocwmma/internal/type_traits.hpp
@@ -27,7 +27,18 @@
 #ifndef ROCWMMA_TYPE_TRAITS_HPP
 #define ROCWMMA_TYPE_TRAITS_HPP
 
+#if !defined(__HIPCC_RTC__)
+
 #include <cfloat>
+
+#else
+
+#define FLT_EPSILON __FLT_EPSILON__
+#define FLT_MAX __FLT_MAX__
+#define FLT_MIN __FLT_MIN__
+#define HUGE_VALF (__builtin_huge_valf ())
+
+#endif // !defined(__HIPCC_RTC__)
 
 #include "types.hpp"
 

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -70,6 +70,9 @@ namespace rocwmma
     using float16_t = _Float16;
     using float32_t = float;
     using float64_t = double;
+
+#if !defined(__HIPCC_RTC__)
+
     using int8_t    = ::int8_t;
     using uint8_t   = ::uint8_t;
     using int16_t   = ::int16_t;
@@ -78,7 +81,21 @@ namespace rocwmma
     using uint32_t  = ::uint32_t;
     using int64_t   = ::int64_t;
     using uint64_t  = ::uint64_t;
-    using index_t   = int32_t;
+    using index_t   = ::int32_t;
+
+#else
+
+    using int8_t    = __hip_internal::int8_t;
+    using uint8_t   = __hip_internal::uint8_t;
+    using int16_t   = __hip_internal::int16_t;
+    using uint16_t  = __hip_internal::uint16_t;
+    using int32_t   = __hip_internal::int32_t;
+    using uint32_t  = __hip_internal::uint32_t;
+    using int64_t   = __hip_internal::int64_t;
+    using uint64_t  = __hip_internal::uint64_t;
+    using index_t   = __hip_internal::int32_t;
+
+#endif // !defined(__HIPCC_RTC__)
 
 // Non-native types
 #if !defined(__HIPCC_RTC__)

--- a/library/include/rocwmma/internal/vector_impl.hpp
+++ b/library/include/rocwmma/internal/vector_impl.hpp
@@ -703,26 +703,26 @@ namespace rocwmma
 #define ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(TYPE, RANK) \
     ROCWMMA_REGISTER_HIP_VECTOR_BASE(TYPE, RANK, ROCWMMA_HIP_NON_NATIVE_VECTOR_STORAGE_IMPL)
 
-////////////////////////
-/// Bfloat16 support ///
-////////////////////////
 
-// HIP bfloat16_t is not supported in RTC environment
-#if !defined(__HIPCC_RTC__)
+#if defined(__HIPCC_RTC__)
+#define ROCWMMA_VEC_OPERATOR ROCWMMA_DEVICE
+#else
+#define ROCWMMA_VEC_OPERATOR ROCWMMA_HOST_DEVICE
+#endif
 
 // Quirk: explicit specialization for ++ / -- operators in HIP_vector_type<bfloat16_t, N>.
 // Why? bfloat16_t doesn't have automatic conversion from integers so we must override the default implementation;
 // Override such that in(de)crement operators use 1.f instead of 1(int)
 #define ROCWMMA_IMPL_VECTOR_INC_DEC_OPS_AS_FLOAT(FLOAT_TYPE, RANK)                        \
     template <>                                                                           \
-    ROCWMMA_HOST_DEVICE inline HIP_vector_type<FLOAT_TYPE, RANK>&                         \
+    ROCWMMA_VEC_OPERATOR inline HIP_vector_type<FLOAT_TYPE, RANK>&                         \
         HIP_vector_type<FLOAT_TYPE, RANK>::operator++() noexcept                          \
     {                                                                                     \
         return *this += HIP_vector_type<FLOAT_TYPE, RANK>{static_cast<FLOAT_TYPE>(1.0f)}; \
     }                                                                                     \
                                                                                           \
     template <>                                                                           \
-    ROCWMMA_HOST_DEVICE inline HIP_vector_type<FLOAT_TYPE, RANK>&                         \
+    ROCWMMA_VEC_OPERATOR inline HIP_vector_type<FLOAT_TYPE, RANK>&                         \
         HIP_vector_type<FLOAT_TYPE, RANK>::operator--() noexcept                          \
     {                                                                                     \
         return *this -= HIP_vector_type<FLOAT_TYPE, RANK>{static_cast<FLOAT_TYPE>(1.0f)}; \
@@ -732,7 +732,5 @@ namespace rocwmma
 #define ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE_WITH_INC_DEC_OPS_AS_FLOAT(TYPE, RANK) \
     ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(TYPE, RANK)                               \
     ROCWMMA_IMPL_VECTOR_INC_DEC_OPS_AS_FLOAT(TYPE, RANK)
-
-#endif // !__HIPCC_RTC__
 
 #endif // ROCWMMA_VECTOR_IMPL_HPP


### PR DESCRIPTION
- Adjusts new datatype code to use drop-in replacements of missing std functions in hipRTC
- Adjusts datatype configuration to use internal types in absence of std integral types.
- Validated can use f8/bf8/xf32 datatypes in hipRTC sample