### PR TITLE
Build all test in large code model

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,9 @@ cmake_dependent_option( ROCWMMA_BUILD_VALIDATION_TESTS "Build validation tests" 
 cmake_dependent_option( ROCWMMA_BUILD_BENCHMARK_TESTS "Build benchmarking tests" OFF "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_BUILD_EXTENDED_TESTS "Build extended test parameter coverage" OFF "ROCWMMA_BUILD_TESTS" OFF )
 
+add_compile_options(-mcmodel=large)
+add_link_options(-mcmodel=large)
+
 # Test/benchmark requires additional dependencies
 include( FetchContent )
 


### PR DESCRIPTION
Some unit test executables are too large to build in default code model(small).

Change the code model of gtest and all test executables to large.

More about code model see
https://eli.thegreenplace.net/2012/01/03/understanding-the-x64-code-models