### PR TITLE
Bump requests from 2.28.2 to 2.31.0 in /docs/.sphinx

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -88,7 +88,7 @@ pyyaml==6.0
     #   myst-parser
     #   rocm-docs-core
     #   sphinx-external-toc
-requests==2.28.2
+requests==2.31.0
     # via
     #   pygithub
     #   sphinx


### PR DESCRIPTION
Duplicated PR of #268. Will be merged into release-staging/rocm-rel-6.0