### PR TITLE
Add predicates for samples

### DIFF
--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -93,7 +93,7 @@ bool isGfx11()
 }
 
 // HIP Host function to find if the device supports f64
-bool isF64Supported()
+uint32_t getGCNArchId()
 {
     hipDevice_t     mHandle;
     hipDeviceProp_t mProps;
@@ -102,16 +102,378 @@ bool isF64Supported()
     CHECK_HIP_ERROR(hipGetDeviceProperties(&mProps, mHandle));
 
     std::string deviceName(mProps.gcnArchName);
+    uint32_t mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_NONE;
 
-    return ((deviceName.find("gfx90a") != std::string::npos)
-            || (deviceName.find("gfx940") != std::string::npos)
-            || (deviceName.find("gfx941") != std::string::npos)
-            || (deviceName.find("gfx942") != std::string::npos));
+    if(deviceName.find("gfx908") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX908;
+    }
+    else if(deviceName.find("gfx90a") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX90A;
+    }
+    else if(deviceName.find("gfx940") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX940;
+    }
+    else if(deviceName.find("gfx941") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX941;
+    }
+    else if(deviceName.find("gfx942") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX942;
+    }
+    else if(deviceName.find("gfx1100") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX1100;
+    }
+    else if(deviceName.find("gfx1101") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX1101;
+    }
+    else if(deviceName.find("gfx1102") != std::string::npos)
+    {
+        mGcnArch = rocwmma::Constants::AMDGCN_ARCH_ID_GFX1102;
+    }
+
+    return mGcnArch;
 }
 
-bool isF32Supported()
+template <uint32_t BlockM,
+          uint32_t BlockN,
+          uint32_t BlockK,
+          typename InputT,
+          typename OutputT,
+          typename ComputeT,
+          uint32_t BlocksX,
+          uint32_t BlocksY,
+          uint32_t TBlockX,
+          uint32_t TBlockY,
+          uint32_t WaveSize,
+          uint32_t ArchId>
+bool checkConfigs()
 {
-    return isGfx9();
+    // Architecture we are testing
+    const bool IsWave32 = (WaveSize == rocwmma::Constants::AMDGCN_WAVE_SIZE_32);
+    const bool IsWave64 = (WaveSize == rocwmma::Constants::AMDGCN_WAVE_SIZE_64);
+
+    const bool IsGfx908  = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX908);
+    const bool IsGfx90A  = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX90A);
+    const bool IsGfx940  = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX940);
+    const bool IsGfx941  = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX941);
+    const bool IsGfx942  = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX942);
+    const bool IsGfx1100 = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX1100);
+    const bool IsGfx1101 = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX1101);
+    const bool IsGfx1102 = (ArchId == rocwmma::Constants::AMDGCN_ARCH_ID_GFX1102);
+
+    const bool IsGfx9  = IsGfx908 || IsGfx90A || IsGfx940 || IsGfx941 || IsGfx942;
+    const bool IsGfx11 = IsGfx1100 || IsGfx1101 || IsGfx1102;
+
+    // Input Types testing
+    const bool IsInputTInt8   = std::is_same_v<InputT, int8_t>;
+    const bool IsInputTFloat8  = std::is_same_v<InputT, rocwmma::float8_t>;
+    const bool IsInputTBFloat8 = std::is_same_v<InputT, rocwmma::bfloat8_t>;
+
+    const bool IsInputTFloat16  = std::is_same_v<InputT, rocwmma::float16_t> || std::is_same_v<InputT, rocwmma::hfloat16_t>;
+    const bool IsInputTBFloat16 = std::is_same_v<InputT, rocwmma::bfloat16_t>;
+
+    const bool IsInputTFloat32  = std::is_same_v<InputT, rocwmma::float32_t>;
+    const bool IsInputTXFloat32 = std::is_same_v<InputT, rocwmma::xfloat32_t>;
+
+    const bool IsInputTFloat64 = std::is_same_v<InputT, rocwmma::float64_t>;
+
+    // Output Types testing
+    const bool IsOutputTInt8    = std::is_same_v<OutputT, int8_t>;
+    const bool IsOutputTFloat8  = std::is_same_v<OutputT, rocwmma::float8_t>;
+    const bool IsOutputTBFloat8 = std::is_same_v<OutputT, rocwmma::bfloat8_t>;
+
+    const bool IsOutputTFloat16  = std::is_same_v<OutputT, rocwmma::float16_t> || std::is_same_v<OutputT, rocwmma::hfloat16_t>;
+    const bool IsOutputTBFloat16 = std::is_same_v<OutputT, rocwmma::bfloat16_t>;
+
+    const bool IsOutputTFloat32  = std::is_same_v<OutputT, rocwmma::float32_t>;
+    const bool IsOutputTXFloat32 = std::is_same_v<OutputT, rocwmma::xfloat32_t>;
+
+    const bool IsOutputTFloat64 = std::is_same_v<OutputT, rocwmma::float64_t>;
+
+    // Compute Types testing
+    const bool IsComputeTInt8    = std::is_same_v<ComputeT, int8_t>;
+    const bool IsComputeTFloat8  = std::is_same_v<ComputeT, rocwmma::float8_t>;
+    const bool IsComputeTBFloat8 = std::is_same_v<ComputeT, rocwmma::bfloat8_t>;
+
+    const bool IsComputeTFloat16 = std::is_same_v<ComputeT, rocwmma::float16_t> || std::is_same_v<ComputeT, rocwmma::hfloat16_t>;
+    const bool IsComputeTBFloat16 = std::is_same_v<ComputeT, rocwmma::bfloat16_t>;
+
+    const bool IsComputeTFloat32  = std::is_same_v<ComputeT, rocwmma::float32_t>;
+    const bool IsComputeTXFloat32 = std::is_same_v<ComputeT, rocwmma::xfloat32_t>;
+
+    const bool IsComputeTFloat64 = std::is_same_v<ComputeT, rocwmma::float64_t>;
+
+    // Block size testing
+    const bool isBlockMN16 = (BlockM == 16u) && (BlockN == 16u);
+    const bool isBlockMN32 = (BlockM == 32u) && (BlockN == 32u);
+
+    // ThreadblockX must be a multiple of the wave size
+    const bool TBlockXTest = (TBlockX % WaveSize == 0u);
+
+    // Ensure that we have at least 1 wave
+    const bool MinTBlockTest = (TBlockX >= WaveSize && TBlockY >= 1);
+
+    // Ensure that we only build for the current compiler target, which
+    // will also exclude the host.
+    const bool CurrentArchTest = (ArchId == rocwmma::Constants::AMDGCN_CURRENT_ARCH_ID);
+
+    // Ensure that we only build for the current wave size
+    const bool CurrentWaveSizeTest = (WaveSize == rocwmma::Constants::AMDGCN_WAVE_SIZE);
+
+    // Only supported hardware allowed
+    const bool ArchTest = (bool)IsGfx9 || (bool)IsGfx11;
+
+    // During the build phase, we have information about current target arch.
+    // This means only the current arch and wave size are valid.
+    const bool EnableBuild
+        = (TBlockXTest && MinTBlockTest && CurrentArchTest && CurrentWaveSizeTest && ArchTest);
+
+    // During run phase on the host, we don't have compile time info about current arch or wave size.
+    // We have to trust that the runtime params obtained through HipDevice will dispatch correctly for
+    // the current arch and wave size.
+    const bool EnableRun = (TBlockXTest && MinTBlockTest && ArchTest);
+
+    const bool EnableGfx9 = []() {
+        const bool ArchTestGfx9 = (bool)IsGfx9;
+
+        const bool WaveSizeTest = (bool)IsWave64;
+
+        const bool TBlockTest
+        = (TBlockX * TBlockY >= rocwmma::Constants::AMDGCN_WAVE_SIZE_64) && (TBlockX * TBlockY <= 256u);
+
+        const bool InputTypesTest
+        = (bool)IsInputTFloat8 || (bool)IsInputTBFloat8
+          || (bool)IsInputTInt8 || (bool)IsInputTFloat16
+          || (bool)IsInputTBFloat16 || (bool)IsInputTFloat32
+          || (bool)IsInputTXFloat32 || (bool)IsInputTFloat64;
+
+        // Gfx940/1/2 arch req'd for float8_t, bfloat8_t and xfloat32_t
+        const bool F8XF32ArchTest
+        = !((bool)IsInputTFloat8 || (bool)IsInputTBFloat8
+          || (bool)IsInputTXFloat32)
+          || (bool)IsGfx940 || (bool)IsGfx941
+          || (bool)IsGfx942;
+
+        // All archs except gfx908 can run float64_t
+        const bool F64ArchTest
+        = !(bool)IsInputTFloat64 || !(bool)IsGfx908;
+
+        // General int8_t block size
+        // BlockM/N = 16; Block K >= 16
+        // BlockM/N = 32; Block K >= 8
+        const bool I8BlockSizeTest
+        = !((bool)IsInputTInt8)
+          || ((bool)isBlockMN16 && (BlockK >= 16u)
+          && (BlockK % 16u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 8u)
+          && (BlockK % 8u == 0u));
+
+        // Follow-on to gfx940/1/2 int8_t.
+        // BlockM/N = 16; Block K >= 32
+        // BlockM/N = 32; Block K >= 16
+        const bool Gfx940I8BlockSizeTest
+        = !((bool)IsInputTInt8
+          && ((bool)IsGfx940 || (bool)IsGfx941
+          || (bool)IsGfx942))
+          || ((bool)isBlockMN16 && (BlockK >= 32u)
+          && (BlockK % 32u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 16u)
+          && (BlockK % 16u == 0u));
+
+        // General float8_t / bfloat8_t block size
+        // BlockM/N = 16; Block K >= 32
+        // BlockM/N = 32; Block K >= 16
+        const bool F8BlockSizeTest
+        = !((bool)IsInputTFloat8 || (bool)IsInputTBFloat8)
+          || ((bool)isBlockMN16 && (BlockK >= 32u)
+          && (BlockK % 32u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 16u)
+          && (BlockK % 16u == 0u));
+
+        // General float16_t / hfloat16_t / bfloat16_t block size
+        // BlockM/N = 16; Block K >= 16
+        // BlockM/N = 32; Block K >= 8
+        const bool F16BlockSizeTest
+        = !((bool)IsInputTFloat16 || (bool)IsInputTBFloat16)
+          || ((bool)isBlockMN16 && (BlockK >= 16u)
+          && (BlockK % 16u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 8u)
+          && (BlockK % 8u == 0u));
+
+        // Older gfx908 arch has half BlockK on bfloat16_t
+        // BlockM/N = 16; Block K >= 8
+        // BlockM/N = 32; Block K >= 4
+        const bool Gfx908BF16BlockSizeTest
+        = !((bool)IsInputTBFloat16 && (bool)IsGfx908)
+          || ((bool)isBlockMN16 && (BlockK >= 8u)
+          && (BlockK % 8u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 4u)
+          && (BlockK % 4u == 0u));
+
+        // General float32_t block size
+        // BlockM/N = 16; Block K >= 4
+        // BlockM/N = 32; Block K >= 2
+        const bool F32BlockSizeTest
+        = !((bool)IsInputTFloat32)
+          || ((bool)isBlockMN16 && (BlockK >= 4u)
+          && (BlockK % 4u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 2u)
+          && (BlockK % 2u == 0u));
+
+        // General xfloat32_t block size
+        // BlockM/N = 16; Block K >= 8
+        // BlockM/N = 32; Block K >= 4
+        const bool XF32BlockSizeTest
+        = !((bool)IsInputTXFloat32)
+          || ((bool)isBlockMN16 && (BlockK >= 8u)
+          && (BlockK % 8u == 0u))
+          || ((bool)isBlockMN32 && (BlockK >= 4u)
+          && (BlockK % 4u == 0u));
+
+        // General float64_t block size
+        // BlockM/N = 16; Block K >= 4
+        const bool F64BlockSizeTest
+        = !((bool)IsInputTFloat64)
+          || ((bool)isBlockMN16 && (BlockK >= 4u)
+          && (BlockK % 4u == 0u));
+
+        return (ArchTestGfx9 && WaveSizeTest && TBlockTest && InputTypesTest && F8XF32ArchTest
+                    && F64ArchTest && I8BlockSizeTest && Gfx940I8BlockSizeTest && F8BlockSizeTest
+                    && F16BlockSizeTest && Gfx908BF16BlockSizeTest && F32BlockSizeTest
+                    && XF32BlockSizeTest && F64BlockSizeTest);
+    };
+
+    const bool EnableGfx11 = []() {
+
+        // Valid for gfx11 only
+        const bool ArchTestGfx11 = (bool)IsGfx11;
+
+        // Wave size on gfx11 is 32
+        const bool WaveSizeTest = (bool)IsWave32;
+
+        // Max recommended TBlock size is 256
+        const bool TBlockTest
+        = (TBlockX * TBlockY >= rocwmma::Constants::AMDGCN_WAVE_SIZE_32) && (TBlockX * TBlockY <= 256u);
+
+        // Input types supported
+        const bool InputTypesTest = (bool)IsInputTInt8
+                            || (bool)IsInputTFloat16
+                            || (bool)IsInputTBFloat16;
+
+        // General int8_t block size
+        // BlockM/N = 16; Block K >= 16
+        const bool I8BlockSizeTest = !((bool)IsInputTInt8)
+                            || ((bool)isBlockMN16 && (BlockK >= 16u)
+                                && (BlockK % 16u == 0u));
+
+        // General float16_t / hfloat16_t / bfloat16_t block size
+        // BlockM/N = 16; Block K >= 16
+        const bool F16BlockSizeTest
+        = !((bool)IsInputTFloat16 || (bool)IsInputTBFloat16)
+            || ((bool)isBlockMN16 && (BlockK >= 16u)
+                && (BlockK % 16u == 0u));
+
+        return (ArchTestGfx11 && WaveSizeTest && TBlockTest && InputTypesTest && I8BlockSizeTest
+                    && F16BlockSizeTest);
+
+    };
+
+    const bool finalEnableBuild = ((bool)EnableBuild
+                                  && ((bool)EnableGfx9 || (bool)EnableGfx11));
+
+    const bool finalEnableRun   = ((bool)EnableRun
+                                  && ((bool)EnableGfx9 || (bool)EnableGfx11));
+
+    return finalEnableBuild && finalEnableRun;
+}
+
+template <uint32_t BlockM,
+          uint32_t BlockN,
+          uint32_t BlockK,
+          typename InputT,
+          typename OutputT,
+          typename ComputeT,
+          uint32_t BlocksX,
+          uint32_t BlocksY,
+          uint32_t TBlockX,
+          uint32_t TBlockY,
+          uint32_t WaveSize>
+const bool canEnable()
+{
+    uint32_t Id = getGCNArchId();
+    // - Arch [gfx908, gfx90a, gfx940, gfx941, gfx942, gfx1100, gfx1101, gfx1102]
+    auto dispatchGuardFunc = [Id]() {
+        bool dispatchResult = false;
+
+#define ROCWMMA_CASE_BODY_ARG0(CASE_LABEL, CASE_IMPL) \
+    case CASE_LABEL:                                  \
+    {                                                 \
+        CASE_IMPL                                     \
+    }                                                 \
+    break;
+
+#define ROCWMMA_CASE_BODY_ARG1(CASE_LABEL, CASE_IMPL, CASE_IMPL_ARG0) \
+    case CASE_LABEL:                                                  \
+    {                                                                 \
+        CASE_IMPL(CASE_IMPL_ARG0)                                     \
+    }                                                                 \
+    break;
+
+#define ROCWMMA_SWITCH_BODY8_ARG1(SWITCH_ARG,                       \
+                                  CASE_IMPL,                        \
+                                  CASE_LABEL0,                      \
+                                  CASE_LABEL1,                      \
+                                  CASE_LABEL2,                      \
+                                  CASE_LABEL3,                      \
+                                  CASE_LABEL4,                      \
+                                  CASE_LABEL5,                      \
+                                  CASE_LABEL6,                      \
+                                  CASE_LABEL7)                      \
+    switch(SWITCH_ARG)                                              \
+    {                                                               \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL0, CASE_IMPL, CASE_LABEL0) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL1, CASE_IMPL, CASE_LABEL1) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL2, CASE_IMPL, CASE_LABEL2) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL3, CASE_IMPL, CASE_LABEL3) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL4, CASE_IMPL, CASE_LABEL4) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL5, CASE_IMPL, CASE_LABEL5) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL6, CASE_IMPL, CASE_LABEL6) \
+        ROCWMMA_CASE_BODY_ARG1(CASE_LABEL7, CASE_IMPL, CASE_LABEL7) \
+    default:;                                                       \
+    }
+
+
+#define CASE_IMPL_ASSIGN1(ARCH_ID) \
+dispatchResult = checkConfigs<BlockM, BlockN, BlockK, InputT, OutputT, ComputeT, BlocksX, BlocksY, TBlockX, TBlockY, WaveSize, ARCH_ID>();
+
+#define DISPATCH_GUARD_BODY                     \
+ROCWMMA_SWITCH_BODY8_ARG1(Id,                   \
+                          CASE_IMPL_ASSIGN1,    \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX908,     \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX90A,     \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX940,     \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX941,     \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX942,     \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX1100,    \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX1101,    \
+                          rocwmma::Constants::AMDGCN_ARCH_ID_GFX1102)
+
+        DISPATCH_GUARD_BODY
+
+#undef CASE_IMPL_ASSIGN1
+#undef DISPATCH_GUARD_BODY
+
+        return dispatchResult;
+    };
+
+    // Finally, execute and return the dispatch guard result
+    return dispatchGuardFunc();
 }
 
 inline double calculateGFlops(uint32_t m, uint32_t n, uint32_t k)

--- a/samples/hipRTC_gemm.cpp
+++ b/samples/hipRTC_gemm.cpp
@@ -52,27 +52,27 @@ using ComputeT = float32_t;
 // Supports ROCWMMA_M/N square sizes of
 // : 16 x 16
 // : 32 x 32
-constexpr uint32_t ROCWMMA_M = 16;
-constexpr uint32_t ROCWMMA_N = 16;
+const uint32_t ROCWMMA_M = 16;
+const uint32_t ROCWMMA_N = 16;
 
 // Supports ROCWMMA_K sizes as
 // : multiples of 16.
-constexpr uint32_t ROCWMMA_K = 16;
+const uint32_t ROCWMMA_K = 16;
 
 // Device warp size
-const int WARP_SIZE =  rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Warp tile: computed by each warp
-constexpr uint32_t BLOCKS_X    = 1u;
-constexpr uint32_t BLOCKS_Y    = 1u;
+const int BLOCKS_X    = 1u;
+const int BLOCKS_Y    = 1u;
 
 // Thread block
 // : T_BLOCK_X must be multiple of WARP_SIZE.
 // Note: Each wave will compute one BLOCK_M x BLOCK_N output block
 // Note: Workgroup will compute
 //  T_BLOCK_X / WARP_SIZE x T_BLOCK_Y output blocks
-constexpr uint32_t T_BLOCK_X = 4 * WARP_SIZE;
-constexpr uint32_t T_BLOCK_Y = 4;
+const uint32_t T_BLOCK_X = 4 * WARP_SIZE;
+const uint32_t T_BLOCK_Y = 4;
 
 std::string source = R"(
 
@@ -88,9 +88,9 @@ using InputT   = bfloat16_t;
 using OutputT  = float32_t;
 using ComputeT = float32_t;
 
-constexpr int ROCWMMA_M = 16;
-constexpr int ROCWMMA_N = 16;
-constexpr int ROCWMMA_K = 16;
+const int ROCWMMA_M = 16;
+const int ROCWMMA_N = 16;
+const int ROCWMMA_K = 16;
 
 // The following device kernel is a naive implementation
 // of blocked GEMM. Each wave will compute one BLOCK_M x BLOCK_N
@@ -182,17 +182,14 @@ char const* src = source.c_str();
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   T_BLOCK_X,
-                   T_BLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/hipRTC_gemm.cpp
+++ b/samples/hipRTC_gemm.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,32 +36,43 @@
 
 #include "common.hpp"
 
-using rocwmma::col_major;
+using rocwmma::bfloat16_t;
 using rocwmma::float16_t;
 using rocwmma::float32_t;
 using rocwmma::float64_t;
+
+using rocwmma::col_major;
 using rocwmma::row_major;
+
+// Types
+using InputT   = bfloat16_t;
+using OutputT  = float32_t;
+using ComputeT = float32_t;
 
 // Supports ROCWMMA_M/N square sizes of
 // : 16 x 16
 // : 32 x 32
-const int ROCWMMA_M = 16;
-const int ROCWMMA_N = 16;
+constexpr uint32_t ROCWMMA_M = 16;
+constexpr uint32_t ROCWMMA_N = 16;
 
 // Supports ROCWMMA_K sizes as
 // : multiples of 16.
-const int ROCWMMA_K = 16;
+constexpr uint32_t ROCWMMA_K = 16;
 
 // Device warp size
-const int WAVE_SIZE = getWarpSize();
+const int WARP_SIZE =  rocwmma::Constants::AMDGCN_WAVE_SIZE;
+
+// Warp tile: computed by each warp
+constexpr uint32_t BLOCKS_X    = 1u;
+constexpr uint32_t BLOCKS_Y    = 1u;
 
 // Thread block
-// : T_BLOCK_X must be multiple of WAVE_SIZE.
+// : T_BLOCK_X must be multiple of WARP_SIZE.
 // Note: Each wave will compute one BLOCK_M x BLOCK_N output block
 // Note: Workgroup will compute
-//  T_BLOCK_X / WAVE_SIZE x T_BLOCK_Y output blocks
-const int T_BLOCK_X = 4 * WAVE_SIZE;
-const int T_BLOCK_Y = 4;
+//  T_BLOCK_X / WARP_SIZE x T_BLOCK_Y output blocks
+constexpr uint32_t T_BLOCK_X = 4 * WARP_SIZE;
+constexpr uint32_t T_BLOCK_Y = 4;
 
 std::string source = R"(
 
@@ -70,6 +81,12 @@ std::string source = R"(
 using rocwmma::float16_t;
 using rocwmma::float32_t;
 using rocwmma::float64_t;
+using rocwmma::bfloat16_t;
+
+
+using InputT   = bfloat16_t;
+using OutputT  = float32_t;
+using ComputeT = float32_t;
 
 constexpr int ROCWMMA_M = 16;
 constexpr int ROCWMMA_N = 16;
@@ -93,34 +110,34 @@ extern "C"
 __global__ void gemm_rocwmma_d(uint32_t         m,
                                uint32_t         n,
                                uint32_t         k,
-                               float16_t const* a,
-                               float16_t const* b,
-                               float32_t const* c,
-                               float32_t*       d,
+                               InputT const* a,
+                               InputT const* b,
+                               OutputT const* c,
+                               OutputT*       d,
                                uint32_t         lda,
                                uint32_t         ldb,
                                uint32_t         ldc,
                                uint32_t         ldd,
-                               float32_t        alpha,
-                               float32_t        beta)
+                               ComputeT        alpha,
+                               ComputeT        beta)
 {
     // Create frags
     auto fragA = rocwmma::fragment<rocwmma::matrix_a,
                                    ROCWMMA_M,
                                    ROCWMMA_N,
                                    ROCWMMA_K,
-                                   float16_t,
+                                   InputT,
                                    rocwmma::row_major>();
     auto fragB = rocwmma::fragment<rocwmma::matrix_b,
                                    ROCWMMA_M,
                                    ROCWMMA_N,
                                    ROCWMMA_K,
-                                   float16_t,
+                                   InputT,
                                    rocwmma::col_major>();
     auto fragC
-        = rocwmma::fragment<rocwmma::accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
+        = rocwmma::fragment<rocwmma::accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT>();
     auto fragAcc
-        = rocwmma::fragment<rocwmma::accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
+        = rocwmma::fragment<rocwmma::accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, ComputeT>();
 
     rocwmma::fill_fragment(fragAcc, 0.0f);
 
@@ -165,6 +182,22 @@ char const* src = source.c_str();
 
 int main()
 {
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   T_BLOCK_X,
+                   T_BLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    {
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
+    }
+
     /// Determine the rocm path to use for build
     // 1. Environment variable
     // 2. Default path
@@ -173,11 +206,11 @@ int main()
     std::string rocWMMAIncludePath = std::string("-I") + rocm_path + std::string("/include");
 
     // gemm parameters
-    uint32_t  m     = 256;
-    uint32_t  n     = 256;
-    uint32_t  k     = 256;
-    float32_t alpha = 2.1f;
-    float32_t beta  = 2.1f;
+    uint32_t m     = 256;
+    uint32_t n     = 256;
+    uint32_t k     = 256;
+    ComputeT alpha = 2.1f;
+    ComputeT beta  = 2.1f;
 
     hiprtcProgram prog;
     CHECK_HIPRTC_ERROR(hiprtcCreateProgram(&prog, src, nullptr, 0, nullptr, nullptr));
@@ -216,7 +249,7 @@ int main()
     CHECK_HIP_ERROR(hipModuleGetFunction(&func, module, "gemm_rocwmma_d"));
 
     // Bounds check
-    if((m < (ROCWMMA_M * T_BLOCK_X / WAVE_SIZE) || n < (ROCWMMA_N * T_BLOCK_Y) || k < ROCWMMA_K)
+    if((m < (ROCWMMA_M * T_BLOCK_X / WARP_SIZE) || n < (ROCWMMA_N * T_BLOCK_Y) || k < ROCWMMA_K)
        || (m % ROCWMMA_M || n % ROCWMMA_N || k % ROCWMMA_K))
     {
         std::cout << "Unsupported size!\n";
@@ -231,11 +264,11 @@ int main()
     std::cout << "Initializing host data..." << std::endl;
 
     // Initialize input matrices
-    std::vector<float16_t> matrixA(m * k);
-    std::vector<float16_t> matrixB(k * n);
-    std::vector<float32_t> matrixC(m * n);
+    std::vector<InputT>  matrixA(m * k);
+    std::vector<InputT>  matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
     // Fill outputs with NaN to catch contamination
-    std::vector<float32_t> matrixD(m * n, std::numeric_limits<float32_t>::signaling_NaN());
+    std::vector<OutputT> matrixD(m * n, std::numeric_limits<OutputT>::signaling_NaN());
 
     fillRand(matrixA.data(), m, k);
     fillRand(matrixB.data(), k, n);
@@ -246,10 +279,10 @@ int main()
     // Allocate and copy device memory
     hipDeviceptr_t d_a, d_b, d_c, d_d;
 
-    const size_t bytesA = matrixA.size() * sizeof(float16_t);
-    const size_t bytesB = matrixB.size() * sizeof(float16_t);
-    const size_t bytesC = matrixC.size() * sizeof(float32_t);
-    const size_t bytesD = matrixD.size() * sizeof(float32_t);
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
+    const size_t bytesD = matrixD.size() * sizeof(OutputT);
 
     CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
     CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
@@ -262,7 +295,7 @@ int main()
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WARP_SIZE),
                         rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
 
     struct
@@ -278,8 +311,8 @@ int main()
         uint32_t       _ldb;
         uint32_t       _ldc;
         uint32_t       _ldd;
-        float32_t      _alpha;
-        float32_t      _beta;
+        ComputeT       _alpha;
+        ComputeT       _beta;
     } args{m, n, k, d_a, d_b, d_c, d_d, lda, ldb, ldc, ldd, alpha, beta};
 
     std::size_t args_size = sizeof(args);
@@ -342,22 +375,22 @@ int main()
     CHECK_HIP_ERROR(hipMemcpy(matrixD.data(), d_d, bytesD, hipMemcpyDeviceToHost));
 
     // Setup and run reference computation
-    std::vector<float32_t> matrixD_ref(m * n, std::numeric_limits<float32_t>::signaling_NaN());
-    gemm_cpu_h<float16_t, float32_t, float32_t, row_major, col_major, row_major>(m,
-                                                                                 n,
-                                                                                 k,
-                                                                                 matrixA.data(),
-                                                                                 matrixB.data(),
-                                                                                 matrixC.data(),
-                                                                                 matrixD_ref.data(),
-                                                                                 lda,
-                                                                                 ldb,
-                                                                                 ldc,
-                                                                                 ldd,
-                                                                                 alpha,
-                                                                                 beta);
+    std::vector<OutputT> matrixD_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    gemm_cpu_h<InputT, OutputT, ComputeT, row_major, col_major, row_major>(m,
+                                                                           n,
+                                                                           k,
+                                                                           matrixA.data(),
+                                                                           matrixB.data(),
+                                                                           matrixC.data(),
+                                                                           matrixD_ref.data(),
+                                                                           lda,
+                                                                           ldb,
+                                                                           ldc,
+                                                                           ldd,
+                                                                           alpha,
+                                                                           beta);
 
-    auto res = compareEqual<float32_t>(matrixD.data(), matrixD_ref.data(), m * n);
+    auto res = compareEqual<OutputT>(matrixD.data(), matrixD_ref.data(), m * n);
 
     if(std::get<0>(res) == false)
     {

--- a/samples/perf_dgemm.cpp
+++ b/samples/perf_dgemm.cpp
@@ -212,7 +212,7 @@ constexpr uint32_t ROCWMMA_N = 16u;
 constexpr uint32_t ROCWMMA_K = 16u;
 
 // Warp size
-constexpr uint32_t WARP_SIZE = Constants::AMDGCN_WAVE_SIZE;
+constexpr uint32_t WARP_SIZE = getWarpSize();
 
 // Warp tile: computed by each warp
 constexpr uint32_t BLOCKS_X    = 2u;
@@ -873,17 +873,14 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   TBLOCK_X,
-                   TBLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/perf_dgemm.cpp
+++ b/samples/perf_dgemm.cpp
@@ -660,7 +660,7 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
     globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
 }
 
-ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha, float64_t beta)
+ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
 {
     // Runtime warp calculation (host code needs to query warpsize dynamically)
     auto warpSize = getWarpSize();
@@ -703,11 +703,11 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
     std::cout << "Initializing host data..." << std::endl;
 
     // Initialize input matrices
-    std::vector<float64_t> matrixA(m * k);
-    std::vector<float64_t> matrixB(k * n);
-    std::vector<float64_t> matrixC(m * n);
+    std::vector<InputT> matrixA(m * k);
+    std::vector<InputT> matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
     // Fill outputs with NaN to catch contamination
-    std::vector<float64_t> matrixD(m * n, std::numeric_limits<float64_t>::signaling_NaN());
+    std::vector<OutputT> matrixD(m * n, std::numeric_limits<OutputT>::signaling_NaN());
 
     fillRand(matrixA.data(), m, k);
     fillRand(matrixB.data(), k, n);
@@ -716,15 +716,15 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
     std::cout << "Initializing device data..." << std::endl;
 
     // Allocate and copy device memory
-    float64_t* d_a;
-    float64_t* d_b;
-    float64_t* d_c;
-    float64_t* d_d;
+    InputT* d_a;
+    InputT* d_b;
+    OutputT* d_c;
+    OutputT* d_d;
 
-    const size_t bytesA = matrixA.size() * sizeof(float64_t);
-    const size_t bytesB = matrixB.size() * sizeof(float64_t);
-    const size_t bytesC = matrixC.size() * sizeof(float64_t);
-    const size_t bytesD = matrixD.size() * sizeof(float64_t);
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
+    const size_t bytesD = matrixD.size() * sizeof(OutputT);
 
     CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
     CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
@@ -746,7 +746,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
 
     // Uses 2 lds blocks for prefetch loop (A and B)
     int ldsusage
-        = 2u * sizeof(float64_t) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * ROCWMMA_K;
+        = 2u * sizeof(InputT) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * ROCWMMA_K;
 
     auto rocwmmaKernel = [&]() {
         hipExtLaunchKernelGGL(gemm_rocwmma_d,
@@ -832,8 +832,8 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
     CHECK_HIP_ERROR(hipMemcpy(matrixD.data(), d_d, bytesD, hipMemcpyDeviceToHost));
 
     // Setup and run reference computation
-    std::vector<float64_t> matrixD_ref(m * n, std::numeric_limits<float64_t>::signaling_NaN());
-    gemm_cpu_h<float64_t, float64_t, float64_t, col_major, row_major, col_major>(m,
+    std::vector<OutputT> matrixD_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    gemm_cpu_h<InputT, OutputT, ComputeT, col_major, row_major, col_major>(m,
                                                                                  n,
                                                                                  k,
                                                                                  matrixA.data(),
@@ -873,14 +873,23 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha,
 
 int main()
 {
-    if(!isF64Supported())
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   TBLOCK_X,
+                   TBLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
     {
-        std::cout << "f64 dgemm not supported on this device" << std::endl;
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
     }
-    else
-    {
-        gemm_test(7168, 7168, 7168, 2, 2);
-    }
+
+    gemm_test(7168, 7168, 7168, 2, 2);
 
     return 0;
 }

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -949,17 +949,14 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   TBLOCK_X,
-                   TBLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -196,10 +196,8 @@ using namespace rocwmma;
 /// Parameter configuration
 ///
 
-/* Many parameters need to be modified in order to obtain maximum performance across different
-*  architectures. This performance sample is setup for running on GFX11 architectures.
-*  Modifying the following parameters will allow for maximum performance on GFX9 Based
-*  architectures.
+/* Depending on the GPU architecture this sample is run on, the following kernel parameters need to
+*  be modified in order to obtain high performance.
 * _________________________________________________________________________________________
 *|         |           |           |           |          |          |          |          |
 *|         | ROCWMMA_M | ROCWMMA_N | ROCWMMA_K | BLOCKS_X | BLOCKS_Y | TBLOCK_X | TBLOCK_Y |
@@ -223,7 +221,46 @@ using namespace rocwmma;
 *|_________|________________________________|
 */
 
-// Types
+namespace gfx9Params
+{
+    enum kernelParams : uint32_t
+    {
+        ROCWMMA_M = 32u,
+        ROCWMMA_N = 32u,
+        ROCWMMA_K = 16u,
+        BLOCKS_X  = 2u,
+        BLOCKS_Y  = 2u,
+        TBLOCK_X  = 128u,
+        TBLOCK_Y  = 2u,
+        WARP_SIZE = Constants::AMDGCN_WAVE_SIZE_64
+    };
+}
+
+namespace gfx11Params
+{
+    enum kernelParams : uint32_t
+    {
+        ROCWMMA_M = 16u,
+        ROCWMMA_N = 16u,
+        ROCWMMA_K = 16u,
+        BLOCKS_X  = 4u,
+        BLOCKS_Y  = 2u,
+        TBLOCK_X  = 64u,
+        TBLOCK_Y  = 4u,
+        WARP_SIZE = Constants::AMDGCN_WAVE_SIZE_32
+    };
+}
+
+#if (ROCWMMA_ARCH_GFX9)
+using namespace gfx9Params;
+#else
+using namespace gfx11Params;
+#endif // defined(ROCWMMA_ARCH_GFX9)
+
+///
+/// Types and Data Layouts
+///
+
 using InputT   = float16_t;
 using OutputT  = float16_t;
 using ComputeT = float32_t;
@@ -233,32 +270,21 @@ using DataLayoutB   = row_major;
 using DataLayoutC   = col_major;
 using DataLayoutLds = row_major;
 
-// Block sizes
-constexpr uint32_t ROCWMMA_M = 16u;
-constexpr uint32_t ROCWMMA_N = 16u;
-constexpr uint32_t ROCWMMA_K = 16u;
+///
+/// Fragment types
+///
 
-// Warp size
-constexpr uint32_t WARP_SIZE = Constants::AMDGCN_WAVE_SIZE_32;
-
+// #if (ROCWMMA_ARCH_GFX9 || ROCWMMA_ARCH_GFX11)
 // Warp tile: computed by each warp
-constexpr uint32_t BLOCKS_X    = 4u;
-constexpr uint32_t BLOCKS_Y    = 2u;
 constexpr uint32_t WARP_TILE_X = BLOCKS_X * ROCWMMA_M;
 constexpr uint32_t WARP_TILE_Y = BLOCKS_Y * ROCWMMA_N;
 
 // Macro Tile: computed by each thread block (workgroup)
 // Note: TBLOCK_X must be multiple of WARP_SIZE.
-constexpr uint32_t TBLOCK_X     = 64u;
-constexpr uint32_t TBLOCK_Y     = 4u;
 constexpr uint32_t WARPS_X      = TBLOCK_X / WARP_SIZE;
 constexpr uint32_t WARPS_Y      = TBLOCK_Y;
 constexpr uint32_t MACRO_TILE_X = WARPS_X * WARP_TILE_X;
 constexpr uint32_t MACRO_TILE_Y = WARPS_Y * WARP_TILE_Y;
-
-///
-/// Fragment types
-///
 
 // Mfma frags
 using MfmaFragA   = fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
@@ -282,6 +308,7 @@ using LWBuffB = ApplyDataLayout_t<ApplyTranspose_t<GRBuffB>, DataLayoutLds>;
 // - Lds has transposed B frags.
 using LRFragA = ApplyDataLayout_t<MfmaFragA, DataLayoutLds>;
 using LRFragB = ApplyDataLayout_t<ApplyTranspose_t<MfmaFragB>, DataLayoutLds>;
+// #endif // (ROCWMMA_ARCH_GFX9 || ROCWMMA_ARCH_GFX11)
 
 ///
 /// Wrapper functions: repeat mfma tile operations across entire warp tile.
@@ -499,6 +526,8 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           ComputeT       alpha,
                                                           ComputeT       beta)
 {
+if constexpr(ROCWMMA_ARCH_GFX9 || ROCWMMA_ARCH_GFX11)
+{
     ///
     /// 2D matrix coordinate setup
     ///
@@ -624,7 +653,7 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
     ///
     /// Accumulate A * B for all mfma frags in warp tile
     ///
-    for(auto currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
+    for(uint32_t currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
     {
         MfmaFragA fragsA[BLOCKS_X];
         MfmaFragB fragsB[BLOCKS_Y];
@@ -686,42 +715,54 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
     uniformFma(fragsD, alpha, fragsAcc, beta, fragsC);
     globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
 }
+}
 
-ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, float32_t beta)
+ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
 {
+    // Runtime checks for host parameters
+    uint32_t hTBLOCK_X = isGfx9() ? gfx9Params::TBLOCK_X : gfx11Params::TBLOCK_X;
+    uint32_t hTBLOCK_Y = isGfx9() ? gfx9Params::TBLOCK_Y : gfx11Params::TBLOCK_Y;
+    uint32_t hBLOCKS_X = isGfx9() ? gfx9Params::BLOCKS_X : gfx11Params::BLOCKS_X;
+    uint32_t hBLOCKS_Y = isGfx9() ? gfx9Params::BLOCKS_Y : gfx11Params::BLOCKS_Y;
+    uint32_t hROCWMMA_M = isGfx9() ? gfx9Params::ROCWMMA_M : gfx11Params::ROCWMMA_M;
+    uint32_t hROCWMMA_N = isGfx9() ? gfx9Params::ROCWMMA_N : gfx11Params::ROCWMMA_N;
+    uint32_t hROCWMMA_K = isGfx9() ? gfx9Params::ROCWMMA_K : gfx11Params::ROCWMMA_K;
+    uint32_t hWARP_TILE_X = hBLOCKS_X * hROCWMMA_M;
+    uint32_t hWARP_TILE_Y = hBLOCKS_Y * hROCWMMA_N;
+
     // Runtime warp calculation (host code needs to query warpsize dynamically)
     auto warpSize = getWarpSize();
     auto macroTileSize
-        = rocwmma::make_coord2d(TBLOCK_X / warpSize * WARP_TILE_X, TBLOCK_Y * WARP_TILE_Y);
+        = rocwmma::make_coord2d(hTBLOCK_X / warpSize * hWARP_TILE_X, hTBLOCK_Y * hWARP_TILE_Y);
 
     // Device check for supported block and wave sizes
-    if(isGfx11() && (ROCWMMA_M != 16 || ROCWMMA_N != 16))
+    if(isGfx11() && (hROCWMMA_M != 16 || hROCWMMA_N != 16))
     {
         std::cout << "Unsupported block size!\n";
         return;
     }
 
-    if(isGfx9() && (ROCWMMA_M != ROCWMMA_N) || (ROCWMMA_M != 16 && ROCWMMA_M != 32))
+    if(isGfx9() && (hROCWMMA_M != hROCWMMA_N) || (hROCWMMA_M != 16 && hROCWMMA_M != 32))
     {
         std::cout << "Unsupported block size!\n";
         return;
     }
 
-    if(isGfx11() && WARP_SIZE != Constants::AMDGCN_WAVE_SIZE_32)
+    if(isGfx11() && getWarpSize() != Constants::AMDGCN_WAVE_SIZE_32)
     {
         std::cout << "Unsupported wave size!\n";
         return;
     }
 
-    if(isGfx9() && WARP_SIZE != Constants::AMDGCN_WAVE_SIZE_64)
+    if(isGfx9() && getWarpSize() != Constants::AMDGCN_WAVE_SIZE_64)
     {
         std::cout << "Unsupported wave size!\n";
         return;
     }
 
     // Bounds check
-    if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < ROCWMMA_K)
-       || (m % ROCWMMA_M || n % ROCWMMA_N || k % ROCWMMA_K))
+    if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < hROCWMMA_K)
+       || (m % hROCWMMA_M || n % hROCWMMA_N || k % hROCWMMA_K))
     {
         std::cout << "Unsupported matrix size!\n";
         return;
@@ -736,9 +777,9 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     std::cout << "Initializing host data..." << std::endl;
 
     // Initialize input matrices
-    std::vector<InputT>   matrixA(m * k);
-    std::vector<InputT>   matrixB(k * n);
-    std::vector<ComputeT> matrixC(m * n);
+    std::vector<InputT>  matrixA(m * k);
+    std::vector<InputT>  matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
 
     // Fill outputs with NaN to catch contamination
     std::vector<OutputT> matrixD(m * n, std::numeric_limits<OutputT>::signaling_NaN());
@@ -770,7 +811,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     CHECK_HIP_ERROR(hipMemcpy(d_c, matrixC.data(), bytesC, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
-    auto blockDim = dim3(TBLOCK_X, TBLOCK_Y);
+    auto blockDim = dim3(hTBLOCK_X, hTBLOCK_Y);
     auto gridDim  = dim3(rocwmma::ceilDiv(m, get<0>(macroTileSize)),
                         rocwmma::ceilDiv(n, get<1>(macroTileSize)));
 
@@ -848,8 +889,8 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
               << "beta, ldc, ldd, "
               << "elapsedMs, Problem Size(GFlops), TFlops/s" << std::endl;
 
-    std::cout << TBLOCK_X << ", " << TBLOCK_Y << ", " << BLOCKS_X << ", " << BLOCKS_Y << ", "
-              << ROCWMMA_M << ", " << ROCWMMA_N << ", " << ROCWMMA_K << ", " << m << ", " << n
+    std::cout << hTBLOCK_X << ", " << hTBLOCK_Y << ", " << hBLOCKS_X << ", " << hBLOCKS_Y << ", "
+              << hROCWMMA_M << ", " << hROCWMMA_N << ", " << hROCWMMA_K << ", " << m << ", " << n
               << ", " << k << ", " << alpha << ", " << lda << ", " << ldb << ", " << beta << ", "
               << ldc << ", " << ldd << ", " << elapsedTimeMs << ", " << gFlops << ", "
               << tFlopsPerSec << std::endl;
@@ -908,6 +949,22 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
 
 int main()
 {
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   TBLOCK_X,
+                   TBLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    {
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
+    }
+
     gemm_test(7168, 7168, 7168, 2, 2);
     return 0;
 }

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -212,7 +212,7 @@ constexpr uint32_t ROCWMMA_N = 32u;
 constexpr uint32_t ROCWMMA_K = 16u;
 
 // Warp size
-constexpr uint32_t WARP_SIZE = Constants::AMDGCN_WAVE_SIZE;
+constexpr uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
 
 // Warp tile: computed by each warp
 constexpr uint32_t BLOCKS_X    = 2u;
@@ -660,7 +660,7 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
     globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
 }
 
-ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, float32_t beta)
+ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
 {
     // Runtime warp calculation (host code needs to query warpsize dynamically)
     auto warpSize = getWarpSize();
@@ -703,11 +703,11 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     std::cout << "Initializing host data..." << std::endl;
 
     // Initialize input matrices
-    std::vector<float32_t> matrixA(m * k);
-    std::vector<float32_t> matrixB(k * n);
-    std::vector<float32_t> matrixC(m * n);
+    std::vector<InputT> matrixA(m * k);
+    std::vector<InputT> matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
     // Fill outputs with NaN to catch contamination
-    std::vector<float32_t> matrixD(m * n, std::numeric_limits<float32_t>::signaling_NaN());
+    std::vector<OutputT> matrixD(m * n, std::numeric_limits<OutputT>::signaling_NaN());
 
     fillRand(matrixA.data(), m, k);
     fillRand(matrixB.data(), k, n);
@@ -716,15 +716,15 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     std::cout << "Initializing device data..." << std::endl;
 
     // Allocate and copy device memory
-    float32_t* d_a;
-    float32_t* d_b;
-    float32_t* d_c;
-    float32_t* d_d;
+    InputT* d_a;
+    InputT* d_b;
+    OutputT* d_c;
+    OutputT* d_d;
 
-    const size_t bytesA = matrixA.size() * sizeof(float32_t);
-    const size_t bytesB = matrixB.size() * sizeof(float32_t);
-    const size_t bytesC = matrixC.size() * sizeof(float32_t);
-    const size_t bytesD = matrixD.size() * sizeof(float32_t);
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
+    const size_t bytesD = matrixD.size() * sizeof(OutputT);
 
     CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
     CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
@@ -746,7 +746,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
 
     // Uses 2 lds blocks for prefetch loop (A and B)
     int ldsusage
-        = 2u * sizeof(float32_t) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * ROCWMMA_K;
+        = 2u * sizeof(InputT) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * ROCWMMA_K;
 
     auto rocwmmaKernel = [&]() {
         hipExtLaunchKernelGGL(gemm_rocwmma_d,
@@ -832,8 +832,8 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
     CHECK_HIP_ERROR(hipMemcpy(matrixD.data(), d_d, bytesD, hipMemcpyDeviceToHost));
 
     // Setup and run reference computation
-    std::vector<float32_t> matrixD_ref(m * n, std::numeric_limits<float32_t>::signaling_NaN());
-    gemm_cpu_h<float32_t, float32_t, float32_t, col_major, row_major, col_major>(m,
+    std::vector<OutputT> matrixD_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    gemm_cpu_h<InputT, OutputT, ComputeT, col_major, row_major, col_major>(m,
                                                                                  n,
                                                                                  k,
                                                                                  matrixA.data(),
@@ -873,13 +873,23 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha,
 
 int main()
 {
-    if(!isF32Supported())
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   TBLOCK_X,
+                   TBLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
     {
-        std::cout << "f32 sgemm not supported on this device" << std::endl;
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
     }
-    else
-    {
-        gemm_test(7168, 7168, 7168, 2, 2);
-    }
+
+    gemm_test(7168, 7168, 7168, 2, 2);
+
     return 0;
 }

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -212,7 +212,7 @@ constexpr uint32_t ROCWMMA_N = 32u;
 constexpr uint32_t ROCWMMA_K = 16u;
 
 // Warp size
-constexpr uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Warp tile: computed by each warp
 constexpr uint32_t BLOCKS_X    = 2u;
@@ -873,17 +873,14 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   TBLOCK_X,
-                   TBLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/simple_dgemm.cpp
+++ b/samples/simple_dgemm.cpp
@@ -57,7 +57,7 @@ constexpr uint32_t ROCWMMA_N = 16;
 constexpr uint32_t ROCWMMA_K = 16;
 
 // Device warp size
-const uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Thread block
 // : T_BLOCK_X must be multiple of WARP_SIZE.
@@ -299,17 +299,14 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, Comp
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   T_BLOCK_X,
-                   T_BLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/simple_dgemv.cpp
+++ b/samples/simple_dgemv.cpp
@@ -73,27 +73,27 @@ __host__ void dgemv_cpu_h(uint32_t         m,
 // Supports ROCWMMA_M/N square sizes of
 // : 16 x 16
 // : 32 x 32 ( only MI )
-constexpr uint32_t ROCWMMA_M = 16;
-constexpr uint32_t ROCWMMA_N = 16;
+const uint32_t ROCWMMA_M = 16;
+const uint32_t ROCWMMA_N = 16;
 
 // Supports ROCWMMA_K sizes as
 // : multiples of 16.
-constexpr uint32_t ROCWMMA_K = 16;
+const uint32_t ROCWMMA_K = 16;
 
 // AMDGCN default wave size
-const uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Warp tile: computed by each warp
-constexpr uint32_t BLOCKS_X    = 1u;
-constexpr uint32_t BLOCKS_Y    = 1u;
+const uint32_t BLOCKS_X    = 1u;
+const uint32_t BLOCKS_Y    = 1u;
 
 // Thread block
 // : T_BLOCK_X must be multiple of WARP_SIZE.
 // Note: Each wave will compute one ROCWMMA_M x ROCWMMA_N output block
 // Note: Workgroup will compute
 //  T_BLOCK_X / WARP_SIZE x T_BLOCK_Y output blocks
-constexpr uint32_t T_BLOCK_X = 16 * WARP_SIZE;
-constexpr uint32_t T_BLOCK_Y = 1;
+const uint32_t T_BLOCK_X = 16 * WARP_SIZE;
+const uint32_t T_BLOCK_Y = 1;
 
 // The following device kernel is a naive implementation
 // of blocked dgemv. Each wave will compute one ROCWMMA_M x ROCWMMA_N
@@ -287,17 +287,14 @@ int main()
     const uint32_t k = 256;
     const uint32_t n = T_BLOCK_Y * ROCWMMA_N;
 
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   T_BLOCK_X,
-                   T_BLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/simple_hgemm.cpp
+++ b/samples/simple_hgemm.cpp
@@ -36,33 +36,40 @@
 
 using rocwmma::accumulator;
 using rocwmma::col_major;
-using rocwmma::float16_t;
-using rocwmma::float32_t;
-using rocwmma::float64_t;
+using rocwmma::row_major;
+
 using rocwmma::matrix_a;
 using rocwmma::matrix_b;
-using rocwmma::row_major;
+
+// Types
+using InputT   = rocwmma::float16_t;
+using OutputT  = rocwmma::float16_t;
+using ComputeT = rocwmma::float32_t;
 
 // Supports ROCWMMA_M/N square sizes of
 // : 16 x 16
 // : 32 x 32 ( only MI )
-const int ROCWMMA_M = 16;
-const int ROCWMMA_N = 16;
+constexpr uint32_t ROCWMMA_M = 16;
+constexpr uint32_t ROCWMMA_N = 16;
 
 // Supports ROCWMMA_K sizes as
 // : multiples of 16.
-const int ROCWMMA_K = 16;
+constexpr uint32_t ROCWMMA_K = 16;
 
 // Device warp size
-const uint32_t WAVE_SIZE = getWarpSize();
+const uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+
+// Warp tile: computed by each warp
+constexpr uint32_t BLOCKS_X    = 1u;
+constexpr uint32_t BLOCKS_Y    = 1u;
 
 // Thread block
-// : T_BLOCK_X must be multiple of WAVE_SIZE.
+// : T_BLOCK_X must be multiple of WARP_SIZE.
 // Note: Each wave will compute one BLOCK_M x BLOCK_N output block
 // Note: Workgroup will compute
-//  T_BLOCK_X / WAVE_SIZE x T_BLOCK_Y output blocks
-const int T_BLOCK_X = 4 * WAVE_SIZE;
-const int T_BLOCK_Y = 4;
+//  T_BLOCK_X / WARP_SIZE x T_BLOCK_Y output blocks
+constexpr uint32_t T_BLOCK_X = 4 * WARP_SIZE;
+constexpr uint32_t T_BLOCK_Y = 4;
 
 // The following device kernel is a naive implementation
 // of blocked GEMM. Each wave will compute one BLOCK_M x BLOCK_N
@@ -81,24 +88,24 @@ const int T_BLOCK_Y = 4;
 __global__ void hgemm_rocwmma_d(uint32_t         m,
                                 uint32_t         n,
                                 uint32_t         k,
-                                float16_t const* a,
-                                float16_t const* b,
-                                float16_t const* c,
-                                float16_t*       d,
+                                InputT const* a,
+                                InputT const* b,
+                                OutputT const* c,
+                                OutputT*       d,
                                 uint32_t         lda,
                                 uint32_t         ldb,
                                 uint32_t         ldc,
                                 uint32_t         ldd,
-                                float32_t        alpha,
-                                float32_t        beta)
+                                ComputeT        alpha,
+                                ComputeT        beta)
 {
     // Create frags
     auto fragA
-        = rocwmma::fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float16_t, row_major>();
+        = rocwmma::fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, row_major>();
     auto fragB
-        = rocwmma::fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float16_t, col_major>();
-    auto fragC   = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float16_t>();
-    auto fragAcc = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
+        = rocwmma::fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, col_major>();
+    auto fragC   = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT>();
+    auto fragAcc = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, ComputeT>();
 
     rocwmma::fill_fragment(fragAcc, 0.0f);
 
@@ -138,10 +145,10 @@ __global__ void hgemm_rocwmma_d(uint32_t         m,
     }
 }
 
-__host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, float32_t beta)
+__host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
 {
     // Bounds check
-    if((m < (ROCWMMA_M * T_BLOCK_X / WAVE_SIZE) || n < (ROCWMMA_N * T_BLOCK_Y) || k < ROCWMMA_K)
+    if((m < (ROCWMMA_M * T_BLOCK_X / WARP_SIZE) || n < (ROCWMMA_N * T_BLOCK_Y) || k < ROCWMMA_K)
        || (m % ROCWMMA_M || n % ROCWMMA_N || k % ROCWMMA_K))
     {
         std::cout << "Unsupported size!\n";
@@ -156,11 +163,11 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     std::cout << "Initializing host data..." << std::endl;
 
     // Initialize input matrices
-    std::vector<float16_t> matrixA(m * k);
-    std::vector<float16_t> matrixB(k * n);
-    std::vector<float16_t> matrixC(m * n);
+    std::vector<InputT> matrixA(m * k);
+    std::vector<InputT> matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
     // Fill outputs with NaN to catch contamination
-    std::vector<float16_t> matrixD(m * n, std::numeric_limits<float16_t>::signaling_NaN());
+    std::vector<OutputT> matrixD(m * n, std::numeric_limits<OutputT>::signaling_NaN());
 
     fillRand(matrixA.data(), m, k);
     fillRand(matrixB.data(), k, n);
@@ -169,15 +176,15 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     std::cout << "Initializing device data..." << std::endl;
 
     // Allocate and copy device memory
-    float16_t* d_a;
-    float16_t* d_b;
-    float16_t* d_c;
-    float16_t* d_d;
+    InputT* d_a;
+    InputT* d_b;
+    OutputT* d_c;
+    OutputT* d_d;
 
-    const size_t bytesA = matrixA.size() * sizeof(float16_t);
-    const size_t bytesB = matrixB.size() * sizeof(float16_t);
-    const size_t bytesC = matrixC.size() * sizeof(float16_t);
-    const size_t bytesD = matrixD.size() * sizeof(float16_t);
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
+    const size_t bytesD = matrixD.size() * sizeof(OutputT);
 
     CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
     CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
@@ -190,7 +197,7 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WARP_SIZE),
                         rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
@@ -251,8 +258,8 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(matrixD.data(), d_d, bytesD, hipMemcpyDeviceToHost));
 
     // Setup and run reference computation
-    std::vector<float16_t> matrixD_ref(m * n, std::numeric_limits<float16_t>::signaling_NaN());
-    gemm_cpu_h<float16_t, float16_t, float32_t, row_major, col_major, row_major>(m,
+    std::vector<OutputT> matrixD_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    gemm_cpu_h<InputT, OutputT, ComputeT, row_major, col_major, row_major>(m,
                                                                                  n,
                                                                                  k,
                                                                                  matrixA.data(),
@@ -266,7 +273,7 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
                                                                                  alpha,
                                                                                  beta);
 
-    auto res = compareEqual<float16_t>(matrixD.data(), matrixD_ref.data(), m * n);
+    auto res = compareEqual<OutputT>(matrixD.data(), matrixD_ref.data(), m * n);
 
     if(std::get<0>(res) == false)
     {
@@ -292,6 +299,22 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
 
 int main()
 {
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   T_BLOCK_X,
+                   T_BLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    {
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
+    }
+
     gemm_test(256, 256, 256, 2.1f, 2.1f);
     return 0;
 }

--- a/samples/simple_hgemm.cpp
+++ b/samples/simple_hgemm.cpp
@@ -57,7 +57,7 @@ constexpr uint32_t ROCWMMA_N = 16;
 constexpr uint32_t ROCWMMA_K = 16;
 
 // Device warp size
-const uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Warp tile: computed by each warp
 constexpr uint32_t BLOCKS_X    = 1u;
@@ -299,17 +299,14 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, Comp
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   T_BLOCK_X,
-                   T_BLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/simple_sgemm.cpp
+++ b/samples/simple_sgemm.cpp
@@ -61,7 +61,7 @@ constexpr uint32_t BLOCKS_X    = 1u;
 constexpr uint32_t BLOCKS_Y    = 1u;
 
 // Device warp size
-const int WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Thread block
 // : T_BLOCK_X must be multiple of WARP_SIZE.
@@ -299,17 +299,14 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, Comp
 
 int main()
 {
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   T_BLOCK_X,
-                   T_BLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
     {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);

--- a/samples/simple_sgemm.cpp
+++ b/samples/simple_sgemm.cpp
@@ -36,33 +36,40 @@
 
 using rocwmma::accumulator;
 using rocwmma::col_major;
-using rocwmma::float16_t;
-using rocwmma::float32_t;
-using rocwmma::float64_t;
+using rocwmma::row_major;
+
 using rocwmma::matrix_a;
 using rocwmma::matrix_b;
-using rocwmma::row_major;
+
+// Types
+using InputT   = rocwmma::float32_t;
+using OutputT  = rocwmma::float32_t;
+using ComputeT = rocwmma::float32_t;
 
 // Supports ROCWMMA_M/N square sizes of
 // : 16 x 16
 // : 32 x 32 ( only MI )
-const int ROCWMMA_M = 16;
-const int ROCWMMA_N = 16;
+constexpr uint32_t ROCWMMA_M = 16;
+constexpr uint32_t ROCWMMA_N = 16;
 
 // Supports ROCWMMA_K sizes as
 // : multiples of 16.
-const int ROCWMMA_K = 16;
+constexpr uint32_t ROCWMMA_K = 16;
+
+// Warp tile: computed by each warp
+constexpr uint32_t BLOCKS_X    = 1u;
+constexpr uint32_t BLOCKS_Y    = 1u;
 
 // Device warp size
-const uint32_t WAVE_SIZE = getWarpSize();
+const int WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
 
 // Thread block
-// : T_BLOCK_X must be multiple of WAVE_SIZE.
+// : T_BLOCK_X must be multiple of WARP_SIZE.
 // Note: Each wave will compute one BLOCK_M x BLOCK_N output block
 // Note: Workgroup will compute
-//  T_BLOCK_X / WAVE_SIZE x T_BLOCK_Y output blocks
-const int T_BLOCK_X = 4 * WAVE_SIZE;
-const int T_BLOCK_Y = 4;
+//  T_BLOCK_X / WARP_SIZE x T_BLOCK_Y output blocks
+constexpr uint32_t T_BLOCK_X = 4 * WARP_SIZE;
+constexpr uint32_t T_BLOCK_Y = 4;
 
 // The following device kernel is a naive implementation
 // of blocked GEMM. Each wave will compute one BLOCK_M x BLOCK_N
@@ -81,24 +88,24 @@ const int T_BLOCK_Y = 4;
 __global__ void sgemm_rocwmma_d(uint32_t         m,
                                 uint32_t         n,
                                 uint32_t         k,
-                                float32_t const* a,
-                                float32_t const* b,
-                                float32_t const* c,
-                                float32_t*       d,
+                                InputT const* a,
+                                InputT const* b,
+                                OutputT const* c,
+                                OutputT*       d,
                                 uint32_t         lda,
                                 uint32_t         ldb,
                                 uint32_t         ldc,
                                 uint32_t         ldd,
-                                float32_t        alpha,
-                                float32_t        beta)
+                                ComputeT        alpha,
+                                ComputeT        beta)
 {
     // Create frags
     auto fragA
-        = rocwmma::fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t, row_major>();
+        = rocwmma::fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, row_major>();
     auto fragB
-        = rocwmma::fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t, col_major>();
-    auto fragC   = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
-    auto fragAcc = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
+        = rocwmma::fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, col_major>();
+    auto fragC   = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT>();
+    auto fragAcc = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT>();
 
     rocwmma::fill_fragment(fragAcc, 0.0f);
 
@@ -138,10 +145,10 @@ __global__ void sgemm_rocwmma_d(uint32_t         m,
     }
 }
 
-__host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, float32_t beta)
+__host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
 {
     // Bounds check
-    if((m < (ROCWMMA_M * T_BLOCK_X / WAVE_SIZE) || n < (ROCWMMA_N * T_BLOCK_Y) || k < ROCWMMA_K)
+    if((m < (ROCWMMA_M * T_BLOCK_X / WARP_SIZE) || n < (ROCWMMA_N * T_BLOCK_Y) || k < ROCWMMA_K)
        || (m % ROCWMMA_M || n % ROCWMMA_N || k % ROCWMMA_K))
     {
         std::cout << "Unsupported size!\n";
@@ -156,11 +163,11 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     std::cout << "Initializing host data..." << std::endl;
 
     // Initialize input matrices
-    std::vector<float32_t> matrixA(m * k);
-    std::vector<float32_t> matrixB(k * n);
-    std::vector<float32_t> matrixC(m * n);
+    std::vector<InputT> matrixA(m * k);
+    std::vector<InputT> matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
     // Fill outputs with NaN to catch contamination
-    std::vector<float32_t> matrixD(m * n, std::numeric_limits<float32_t>::signaling_NaN());
+    std::vector<OutputT> matrixD(m * n, std::numeric_limits<OutputT>::signaling_NaN());
 
     fillRand(matrixA.data(), m, k);
     fillRand(matrixB.data(), k, n);
@@ -169,15 +176,15 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     std::cout << "Initializing device data..." << std::endl;
 
     // Allocate and copy device memory
-    float32_t* d_a;
-    float32_t* d_b;
-    float32_t* d_c;
-    float32_t* d_d;
+    InputT* d_a;
+    InputT* d_b;
+    OutputT* d_c;
+    OutputT* d_d;
 
-    const size_t bytesA = matrixA.size() * sizeof(float32_t);
-    const size_t bytesB = matrixB.size() * sizeof(float32_t);
-    const size_t bytesC = matrixC.size() * sizeof(float32_t);
-    const size_t bytesD = matrixD.size() * sizeof(float32_t);
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
+    const size_t bytesD = matrixD.size() * sizeof(OutputT);
 
     CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
     CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
@@ -190,7 +197,7 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WARP_SIZE),
                         rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
@@ -251,8 +258,8 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(matrixD.data(), d_d, bytesD, hipMemcpyDeviceToHost));
 
     // Setup and run reference computation
-    std::vector<float32_t> matrixD_ref(m * n, std::numeric_limits<float32_t>::signaling_NaN());
-    gemm_cpu_h<float32_t, float32_t, float32_t, row_major, col_major, row_major>(m,
+    std::vector<OutputT> matrixD_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    gemm_cpu_h<InputT, OutputT, ComputeT, row_major, col_major, row_major>(m,
                                                                                  n,
                                                                                  k,
                                                                                  matrixA.data(),
@@ -266,7 +273,7 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
                                                                                  alpha,
                                                                                  beta);
 
-    auto res = compareEqual<float32_t>(matrixD.data(), matrixD_ref.data(), m * n);
+    auto res = compareEqual<OutputT>(matrixD.data(), matrixD_ref.data(), m * n);
 
     if(std::get<0>(res) == false)
     {
@@ -292,13 +299,23 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
 
 int main()
 {
-    if(!isF32Supported())
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   T_BLOCK_X,
+                   T_BLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
     {
-        std::cout << "f32 sgemm not supported on this device" << std::endl;
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
     }
-    else
-    {
-        gemm_test(256, 256, 256, 2.1f, 2.1f);
-    }
+
+    gemm_test(256, 256, 256, 2.1f, 2.1f);
+
     return 0;
 }

--- a/samples/simple_sgemv.cpp
+++ b/samples/simple_sgemv.cpp
@@ -81,7 +81,7 @@ constexpr uint32_t ROCWMMA_N = 16;
 constexpr uint32_t ROCWMMA_K = 16;
 
 // AMDGCN default wave size
-const uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+const int WARP_SIZE = getWarpSize();
 
 // Warp tile: computed by each warp
 constexpr uint32_t BLOCKS_X    = 1u;
@@ -287,18 +287,15 @@ int main()
     const uint32_t k = 256;
     const uint32_t n = T_BLOCK_Y * ROCWMMA_N;
 
-    if (!canEnable<ROCWMMA_M,
-                   ROCWMMA_N,
-                   ROCWMMA_K,
-                   InputT,
-                   OutputT,
-                   ComputeT,
-                   BLOCKS_X,
-                   BLOCKS_Y,
-                   T_BLOCK_X,
-                   T_BLOCK_Y,
-                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
-    {
+    if (!isSupportedConfig <ROCWMMA_M,
+                            ROCWMMA_N,
+                            ROCWMMA_K,
+                            InputT,
+                            OutputT,
+                            ComputeT,
+                            BLOCKS_X,
+                            BLOCKS_Y>( T_BLOCK_X, T_BLOCK_Y))
+   {
         std::cout << " Unsupported configurations " << std::endl;
         exit(0);
     }

--- a/samples/simple_sgemv.cpp
+++ b/samples/simple_sgemv.cpp
@@ -37,29 +37,34 @@
 
 using rocwmma::accumulator;
 using rocwmma::col_major;
-using rocwmma::float32_t;
+using rocwmma::row_major;
+
 using rocwmma::matrix_a;
 using rocwmma::matrix_b;
-using rocwmma::row_major;
+
+// Types
+using InputT   = rocwmma::float32_t;
+using OutputT  = rocwmma::float32_t;
+using ComputeT = rocwmma::float32_t;
 
 // Host sgemv validation
 __host__ void sgemv_cpu_h(uint32_t         m,
                           uint32_t         n,
                           uint32_t         k,
-                          float32_t const* a,
-                          float32_t const* b,
-                          float32_t*       c,
-                          float32_t        alpha,
-                          float32_t        beta)
+                          InputT const* a,
+                          InputT const* b,
+                          OutputT*       c,
+                          ComputeT        alpha,
+                          ComputeT        beta)
 {
     uint32_t lda = m;
 
     for(int i = 0; i < m; ++i)
     {
-        float32_t accum = 0.0f;
+        ComputeT accum = 0.0f;
         for(int h = 0; h < k; ++h)
         {
-            accum += static_cast<float32_t>(a[h * lda + i]) * static_cast<float32_t>(b[h]);
+            accum += static_cast<ComputeT>(a[h * lda + i]) * static_cast<ComputeT>(b[h]);
         }
         c[i] = alpha * accum + beta * c[i];
     }
@@ -68,23 +73,27 @@ __host__ void sgemv_cpu_h(uint32_t         m,
 // Supports ROCWMMA_M/N square sizes of
 // : 16 x 16
 // : 32 x 32 ( only MI )
-const int ROCWMMA_M = 16;
-const int ROCWMMA_N = 16;
+constexpr uint32_t ROCWMMA_M = 16;
+constexpr uint32_t ROCWMMA_N = 16;
 
 // Supports ROCWMMA_K sizes as
 // : multiples of 16.
-const int ROCWMMA_K = 16;
+constexpr uint32_t ROCWMMA_K = 16;
 
 // AMDGCN default wave size
-const uint32_t WAVE_SIZE = getWarpSize();
+const uint32_t WARP_SIZE = rocwmma::Constants::AMDGCN_WAVE_SIZE;
+
+// Warp tile: computed by each warp
+constexpr uint32_t BLOCKS_X    = 1u;
+constexpr uint32_t BLOCKS_Y    = 1u;
 
 // Thread block
-// : T_BLOCK_X must be multiple of WAVE_SIZE.
+// : T_BLOCK_X must be multiple of WARP_SIZE.
 // Note: Each wave will compute one ROCWMMA_M x ROCWMMA_N output block
 // Note: Workgroup will compute
-//  T_BLOCK_X / WAVE_SIZE x T_BLOCK_Y output blocks
-const int T_BLOCK_X = 16 * WAVE_SIZE;
-const int T_BLOCK_Y = 1;
+//  T_BLOCK_X / WARP_SIZE x T_BLOCK_Y output blocks
+constexpr uint32_t T_BLOCK_X = 16 * WARP_SIZE;
+constexpr uint32_t T_BLOCK_Y = 1;
 
 // The following device kernel is a naive implementation
 // of blocked SGEMV. Each wave will compute one ROCWMMA_M x ROCWMMA_N
@@ -103,24 +112,24 @@ const int T_BLOCK_Y = 1;
 __global__ void sgemv_rocwmma_d(uint32_t         m,
                                 uint32_t         n,
                                 uint32_t         k,
-                                float32_t const* a,
-                                float32_t const* b,
-                                float32_t*       c,
-                                float32_t*       d,
+                                InputT const* a,
+                                InputT const* b,
+                                OutputT*       c,
+                                OutputT*       d,
                                 uint32_t         lda,
                                 uint32_t         ldb,
                                 uint32_t         ldc,
                                 uint32_t         ldd,
-                                float32_t        alpha,
-                                float32_t        beta)
+                                ComputeT        alpha,
+                                ComputeT        beta)
 {
     // Create frags
     auto fragA
-        = rocwmma::fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t, col_major>();
+        = rocwmma::fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, col_major>();
     auto fragB
-        = rocwmma::fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t, col_major>();
-    auto fragC   = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
-    auto fragAcc = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, float32_t>();
+        = rocwmma::fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, col_major>();
+    auto fragC   = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT>();
+    auto fragAcc = rocwmma::fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, ComputeT>();
 
     rocwmma::fill_fragment(fragAcc, 0.0f);
 
@@ -170,22 +179,22 @@ __host__ void sgemv_test(uint32_t m, uint32_t n, uint32_t k, float alpha, float 
 
     std::cout << "Initializing host data..." << std::endl;
     // Initialize input matrices
-    std::vector<float32_t> matrixA(m * k); // matrix
-    std::vector<float32_t> matrixB(k * 1); // vector
-    std::vector<float32_t> matrixC(m * 1, 1.0); //accum
+    std::vector<InputT> matrixA(m * k); // matrix
+    std::vector<InputT> matrixB(k * 1); // vector
+    std::vector<OutputT> matrixC(m * 1, 1.0); //accum
 
     fillRand(matrixA.data(), m, k);
     fillRand(matrixB.data(), k, 1);
 
     std::cout << "Initializing device data..." << std::endl;
     // Allocate and copy device memory
-    float32_t* d_a;
-    float32_t* d_b;
-    float32_t* d_c;
+    InputT* d_a;
+    InputT* d_b;
+    OutputT* d_c;
 
-    const size_t bytesA = matrixA.size() * sizeof(float32_t);
-    const size_t bytesB = matrixB.size() * sizeof(float32_t);
-    const size_t bytesC = matrixC.size() * sizeof(float32_t);
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
 
     CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
     CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
@@ -196,7 +205,7 @@ __host__ void sgemv_test(uint32_t m, uint32_t n, uint32_t k, float alpha, float 
     CHECK_HIP_ERROR(hipMemcpy(d_c, matrixC.data(), bytesC, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WARP_SIZE),
                         rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching sgemv kernel..." << std::endl;
@@ -242,14 +251,14 @@ __host__ void sgemv_test(uint32_t m, uint32_t n, uint32_t k, float alpha, float 
 
     std::cout << "Validating result with reference..." << std::endl;
     // Bring kernel result back to host
-    std::vector<float32_t> matrixC_device(m, std::numeric_limits<float32_t>::signaling_NaN());
+    std::vector<OutputT> matrixC_device(m, std::numeric_limits<OutputT>::signaling_NaN());
     CHECK_HIP_ERROR(hipMemcpy(matrixC_device.data(), d_c, bytesC, hipMemcpyDeviceToHost));
 
     // Setup and run reference computation
-    std::vector<float32_t> matrixC_host(matrixC);
+    std::vector<OutputT> matrixC_host(matrixC);
     sgemv_cpu_h(m, n, k, matrixA.data(), matrixB.data(), matrixC_host.data(), alpha, beta);
 
-    auto res = compareEqual<float32_t>(matrixC_host.data(), matrixC_device.data(), m);
+    auto res = compareEqual<OutputT>(matrixC_host.data(), matrixC_device.data(), m);
 
     if(std::get<0>(res) == false)
     {
@@ -278,13 +287,23 @@ int main()
     const uint32_t k = 256;
     const uint32_t n = T_BLOCK_Y * ROCWMMA_N;
 
-    if(!isF32Supported())
+    if (!canEnable<ROCWMMA_M,
+                   ROCWMMA_N,
+                   ROCWMMA_K,
+                   InputT,
+                   OutputT,
+                   ComputeT,
+                   BLOCKS_X,
+                   BLOCKS_Y,
+                   T_BLOCK_X,
+                   T_BLOCK_Y,
+                   rocwmma::Constants::AMDGCN_WAVE_SIZE>())
     {
-        std::cout << "f32 sgemv not supported on this device" << std::endl;
+        std::cout << " Unsupported configurations " << std::endl;
+        exit(0);
     }
-    else
-    {
-        sgemv_test(m, n, k, 2.1f, 2.1f);
-    }
+
+    sgemv_test(m, n, k, 2.1f, 2.1f);
+
     return 0;
 }


### PR DESCRIPTION
Consolidate all samples to use compile time params for arguments
To extract predicate checks from tests
to allow compile time architecture detection

TODO:
To allow compile time wave size, tblockx setting